### PR TITLE
Adding test code for the browse put method

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	errInvalidFilePath = agent.Error("Invalid path. Ensure that the path do not contain '..' elements")
-	errUploadFile      = agent.Error("Error with uploaded file, or file already exists")
 )
 
 // FileInfo represents information about a file on the filesystem
@@ -111,25 +110,18 @@ func RenameFileInsideVolume(volumeID, oldPath, newPath string) error {
 	return os.Rename(oldPathInsideVolume, newPathInsideVolume)
 }
 
-// UploadFileToVolume takes a volume, path, filename, and file and writes it to that volume
-func UploadFileToVolume(volumeID, uploadedFilePath, filename string, file []byte) error {
+// UploadFileInVolume takes a volume, path, and file and writes it to that volume
+func UploadFileInVolume(volumeID, uploadedFilePath string, file []byte) error {
 
 	pathInsideVolume, err := buildPathToFileInsideVolume(volumeID, uploadedFilePath)
 	if err != nil {
 		return err
 	}
 
-	os.MkdirAll(pathInsideVolume, 0644)
+	dir, _ := path.Split(pathInsideVolume)
+	os.MkdirAll(dir, 0644)
 
-	filePath := path.Join(pathInsideVolume, filename)
-
-	//Check to see if the file already exists
-	_, err = os.Stat(filePath)
-	if !os.IsNotExist(err) {
-		return errUploadFile
-	}
-
-	err = ioutil.WriteFile(filePath, file, 0644)
+	err = ioutil.WriteFile(pathInsideVolume, file, 0644)
 	if err != nil {
 		return err
 	}

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	errInvalidFilePath = agent.Error("Invalid path. Ensure that the path do not contain '..' elements")
-	errUploadFile      = agent.Error("Error with uploaded file, or file already exists")
 )
 
 // FileInfo represents information about a file on the filesystem
@@ -111,8 +110,8 @@ func RenameFileInsideVolume(volumeID, oldPath, newPath string) error {
 	return os.Rename(oldPathInsideVolume, newPathInsideVolume)
 }
 
-// UploadFileToVolume takes a volume, path, filename, and file and writes it to that volume
-func UploadFileToVolume(volumeID, uploadedFilePath, filename string, file []byte) error {
+// UploadFileInVolume takes a volume, path, filename, and file and writes it to that volume
+func UploadFileInVolume(volumeID, uploadedFilePath, filename string, file []byte) error {
 
 	pathInsideVolume, err := buildPathToFileInsideVolume(volumeID, uploadedFilePath)
 	if err != nil {
@@ -122,12 +121,6 @@ func UploadFileToVolume(volumeID, uploadedFilePath, filename string, file []byte
 	os.MkdirAll(pathInsideVolume, 0644)
 
 	filePath := path.Join(pathInsideVolume, filename)
-
-	//Check to see if the file already exists
-	_, err = os.Stat(filePath)
-	if !os.IsNotExist(err) {
-		return errUploadFile
-	}
 
 	err = ioutil.WriteFile(filePath, file, 0644)
 	if err != nil {

--- a/http/handler/browse/browse_test.go
+++ b/http/handler/browse/browse_test.go
@@ -6,55 +6,200 @@ import (
 	"mime/multipart"
 	"net/http/httptest"
 	"os"
+	"path"
 	"strings"
 	"testing"
 
 	"github.com/portainer/agent"
 )
 
-func TestBrowsePut(t *testing.T) {
-
+func TestBrowseSuccesses(t *testing.T) {
 	var tags map[string]string
 	var clusterService agent.ClusterService
 	handler := NewHandler(clusterService, tags)
-	values := map[string]io.Reader{
-		"file": mustOpen("put_test.txt"),
-		"Path": strings.NewReader("/testing"),
-	}
+	filepath := "/testing"
+	file := "put_test.txt"
 
-	var b bytes.Buffer
-	w := multipart.NewWriter(&b)
-	for key, r := range values {
-		var fw io.Writer
-		var err error
-		if x, ok := r.(io.Closer); ok {
-			defer x.Close()
+	t.Run("BrowsePut", func(t *testing.T) {
+		values := map[string]io.Reader{
+			"file": mustOpen(file),
+			"Path": strings.NewReader(filepath),
 		}
-		// Add an image file
-		if x, ok := r.(*os.File); ok {
-			if fw, err = w.CreateFormFile(key, x.Name()); err != nil {
+
+		var b bytes.Buffer
+		w := multipart.NewWriter(&b)
+		for key, r := range values {
+			var fw io.Writer
+			var err error
+			if x, ok := r.(io.Closer); ok {
+				defer x.Close()
+			}
+			if x, ok := r.(*os.File); ok {
+				if fw, err = w.CreateFormFile(key, x.Name()); err != nil {
+					return
+				}
+			} else {
+				if fw, err = w.CreateFormField(key); err != nil {
+					return
+				}
+			}
+			if _, err = io.Copy(fw, r); err != nil {
 				return
 			}
-		} else {
-			// Add other fields
-			if fw, err = w.CreateFormField(key); err != nil {
+
+		}
+		w.Close()
+
+		request := httptest.NewRequest("POST", "/browse/test/put", &b)
+		request.Header.Set("Content-Type", w.FormDataContentType())
+		writer := httptest.NewRecorder()
+		handler.ServeHTTP(writer, request)
+		if writer.Result().StatusCode != 204 {
+			t.Error("Failed to upload file.", writer.Result().Status)
+		}
+	})
+
+	t.Run("BrowseDelete", func(t *testing.T) {
+		deletePath := path.Join(filepath, file)
+		request := httptest.NewRequest("DELETE", "/browse/test/delete?path="+deletePath, nil)
+		writer := httptest.NewRecorder()
+		handler.ServeHTTP(writer, request)
+		if writer.Result().StatusCode != 204 {
+			t.Error("Failed to delete file.", writer.Result().Status)
+		}
+	})
+}
+
+func TestBrowseFail(t *testing.T) {
+	var tags map[string]string
+	var clusterService agent.ClusterService
+	handler := NewHandler(clusterService, tags)
+	file := "put_test.txt"
+
+	t.Run("BrowsePutMissingPath", func(t *testing.T) {
+		values := map[string]io.Reader{
+			"file": mustOpen(file),
+		}
+
+		var b bytes.Buffer
+		w := multipart.NewWriter(&b)
+		for key, r := range values {
+			var fw io.Writer
+			var err error
+			if x, ok := r.(io.Closer); ok {
+				defer x.Close()
+			}
+			if x, ok := r.(*os.File); ok {
+				if fw, err = w.CreateFormFile(key, x.Name()); err != nil {
+					return
+				}
+			} else {
+				if fw, err = w.CreateFormField(key); err != nil {
+					return
+				}
+			}
+			if _, err = io.Copy(fw, r); err != nil {
 				return
 			}
+
 		}
-		if _, err = io.Copy(fw, r); err != nil {
-			return
+		w.Close()
+
+		request := httptest.NewRequest("POST", "/browse/test/put", &b)
+		request.Header.Set("Content-Type", w.FormDataContentType())
+		writer := httptest.NewRecorder()
+		handler.ServeHTTP(writer, request)
+		if writer.Result().StatusCode != 400 {
+			t.Error("Failed to handle missing path", writer.Result().Status)
+		}
+	})
+
+	t.Run("BrowsePutMissingFile", func(t *testing.T) {
+		filepath := "/testing"
+		values := map[string]io.Reader{
+			"Path": strings.NewReader(filepath),
+		}
+		var b bytes.Buffer
+		w := multipart.NewWriter(&b)
+		for key, r := range values {
+			var fw io.Writer
+			var err error
+			if x, ok := r.(io.Closer); ok {
+				defer x.Close()
+			}
+			if x, ok := r.(*os.File); ok {
+				if fw, err = w.CreateFormFile(key, x.Name()); err != nil {
+					return
+				}
+			} else {
+				if fw, err = w.CreateFormField(key); err != nil {
+					return
+				}
+			}
+			if _, err = io.Copy(fw, r); err != nil {
+				return
+			}
+
+		}
+		w.Close()
+
+		request := httptest.NewRequest("POST", "/browse/test/put", &b)
+		request.Header.Set("Content-Type", w.FormDataContentType())
+		writer := httptest.NewRecorder()
+		handler.ServeHTTP(writer, request)
+		if writer.Result().StatusCode != 400 {
+			t.Error("Failed to handle missing file", writer.Result().Status)
+		}
+	})
+
+	t.Run("BrowsePutUnableToStoreFile", func(t *testing.T) {
+		filepath := "/testing"
+		values := map[string]io.Reader{
+			"file": mustOpen(file),
+			"Path": strings.NewReader(filepath),
 		}
 
-	}
-	w.Close()
+		var b bytes.Buffer
+		w := multipart.NewWriter(&b)
+		for key, r := range values {
+			var fw io.Writer
+			var err error
+			if x, ok := r.(io.Closer); ok {
+				defer x.Close()
+			}
+			if x, ok := r.(*os.File); ok {
+				if fw, err = w.CreateFormFile(key, x.Name()); err != nil {
+					return
+				}
+			} else {
+				if fw, err = w.CreateFormField(key); err != nil {
+					return
+				}
+			}
+			if _, err = io.Copy(fw, r); err != nil {
+				return
+			}
 
-	request := httptest.NewRequest("POST", "/browse/test/put", &b)
-	request.Header.Set("Content-Type", w.FormDataContentType())
-	writer := httptest.NewRecorder()
-	handler.ServeHTTP(writer, request)
-	if writer.Result().StatusCode != 204 {
-		t.Error("Failed to upload file.", writer.Result().Status)
-	}
+		}
+		w.Close()
+
+		request := httptest.NewRequest("POST", "/browse/bad/put", &b)
+		request.Header.Set("Content-Type", w.FormDataContentType())
+		writer := httptest.NewRecorder()
+		handler.ServeHTTP(writer, request)
+		if writer.Result().StatusCode != 500 {
+			t.Error("Failed", writer.Result().Status)
+		}
+	})
+
+	t.Run("BrowseDeleteMissingPath", func(t *testing.T) {
+		request := httptest.NewRequest("DELETE", "/browse/test/delete", nil)
+		writer := httptest.NewRecorder()
+		handler.ServeHTTP(writer, request)
+		if writer.Result().StatusCode != 400 {
+			t.Error("Didn't return an error for missing path", writer.Result().Status)
+		}
+	})
 }
 
 func mustOpen(f string) *os.File {

--- a/http/handler/browse/browse_test.go
+++ b/http/handler/browse/browse_test.go
@@ -1,0 +1,66 @@
+package browse
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/portainer/agent"
+)
+
+func TestBrowsePut(t *testing.T) {
+
+	var tags map[string]string
+	var clusterService agent.ClusterService
+	handler := NewHandler(clusterService, tags)
+	values := map[string]io.Reader{
+		"file": mustOpen("put_test.txt"),
+		"Path": strings.NewReader("/testing"),
+	}
+
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	for key, r := range values {
+		var fw io.Writer
+		var err error
+		if x, ok := r.(io.Closer); ok {
+			defer x.Close()
+		}
+		// Add an image file
+		if x, ok := r.(*os.File); ok {
+			if fw, err = w.CreateFormFile(key, x.Name()); err != nil {
+				return
+			}
+		} else {
+			// Add other fields
+			if fw, err = w.CreateFormField(key); err != nil {
+				return
+			}
+		}
+		if _, err = io.Copy(fw, r); err != nil {
+			return
+		}
+
+	}
+	w.Close()
+
+	request := httptest.NewRequest("POST", "/browse/test/put", &b)
+	request.Header.Set("Content-Type", w.FormDataContentType())
+	writer := httptest.NewRecorder()
+	handler.ServeHTTP(writer, request)
+	if writer.Result().StatusCode != 204 {
+		t.Error("Failed to upload file.", writer.Result().Status)
+	}
+}
+
+func mustOpen(f string) *os.File {
+	r, err := os.Open(f)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}

--- a/http/handler/browse/put_test.txt
+++ b/http/handler/browse/put_test.txt
@@ -1,0 +1,1 @@
+testing file


### PR DESCRIPTION
This function creates a local file in the path it thinks you have a volume

Caveats - 
Since you're not running in a docker environment you'll need /var/lib/docker/volumes/test/_data/testing/ created to support uploading the file there.
Currently the method will fail if you try to upload a file that already exists. A series of tests should be created that upload and then delete the file. 