### PR TITLE
feat(docker): skip ingress network if found during IP detection

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -2,7 +2,7 @@
 
 LOG_LEVEL=DEBUG
 CAP_HOST_MANAGEMENT=1 #Enabled by default. Change this to anything else to disable this feature
-EDGE=1
+EDGE=0
 TMP="/tmp"
 GIT_COMMIT_HASH=`git rev-parse --short HEAD`
 GIT_BRANCH_NAME=`git rev-parse --abbrev-ref HEAD`
@@ -84,7 +84,7 @@ function deploy_swarm() {
 
   echo "Deployment..."
 
-  docker -H "${DOCKER_MANAGER}:2375" network create --driver overlay --attachable portainer-agent-dev-net
+  docker -H "${DOCKER_MANAGER}:2375" network create --driver overlay portainer-agent-dev-net
   docker -H "${DOCKER_MANAGER}:2375" service create --name portainer-agent-dev \
   --network portainer-agent-dev-net \
   -e LOG_LEVEL="${LOG_LEVEL}" \
@@ -96,7 +96,7 @@ function deploy_swarm() {
   --mount type=bind,src=//var/run/docker.sock,dst=/var/run/docker.sock \
   --mount type=bind,src=//var/lib/docker/volumes,dst=/var/lib/docker/volumes \
   --mount type=bind,src=//,dst=/host \
-  --publish mode=host,target=9001,published=9001 \
+  --publish target=9001,published=9001 \
   --publish mode=host,published=80,target=80 \
   --restart-condition none \
   "${IMAGE_NAME}"

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -58,9 +58,13 @@ func (service *InfoService) GetContainerIpFromDockerEngine(containerName string)
 		return "", err
 	}
 
-	for _, network := range containerInspect.NetworkSettings.Networks {
-		if network.IPAddress != "" {
-			log.Printf("[DEBUG] [docker] [network_count: %d] [ip_address: %s] [message: Retrieving IP address from container networks]", len(containerInspect.NetworkSettings.Networks), network.IPAddress)
+	if len(containerInspect.NetworkSettings.Networks) > 1 {
+		log.Printf("[WARN] [docker] [network_count: %d] [message: Agent container running in more than a single Docker network. This might cause communication issues.]", len(containerInspect.NetworkSettings.Networks))
+	}
+
+	for name, network := range containerInspect.NetworkSettings.Networks {
+		if name != "ingress" && network.IPAddress != "" {
+			log.Printf("[DEBUG] [docker] [ip_address: %s] [message: Retrieving IP address from container networks]", network.IPAddress)
 			return network.IPAddress, nil
 		}
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -59,7 +59,7 @@ func (service *InfoService) GetContainerIpFromDockerEngine(containerName string)
 	}
 
 	if len(containerInspect.NetworkSettings.Networks) > 1 {
-		log.Printf("[WARN] [docker] [network_count: %d] [message: Agent container running in more than a single Docker network. This might cause communication issues.]", len(containerInspect.NetworkSettings.Networks))
+		log.Printf("[WARN] [docker] [network_count: %d] [message: Agent container running in more than a single Docker network. This might cause communication issues]", len(containerInspect.NetworkSettings.Networks))
 	}
 
 	for name, network := range containerInspect.NetworkSettings.Networks {

--- a/serf/cluster.go
+++ b/serf/cluster.go
@@ -1,6 +1,7 @@
 package serf
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -40,6 +41,7 @@ func (service *ClusterService) Create(advertiseAddr string, joinAddr []string) e
 
 	conf := serf.DefaultConfig()
 	conf.Init()
+	conf.NodeName = fmt.Sprintf("%s-%s", service.tags[agent.MemberTagKeyNodeName], conf.NodeName)
 	conf.Tags = service.tags
 	conf.MemberlistConfig.LogOutput = filter
 	conf.LogOutput = filter


### PR DESCRIPTION
This PR will automatically skips the `ingress` network if the agent is deployed using regular port mapping (using Swarm service mesh) to avoid communication issues over an invalid network.