### PR TITLE
feat(serf): update agent nodeName to include information about the ho…

### DIFF
--- a/serf/cluster.go
+++ b/serf/cluster.go
@@ -1,6 +1,7 @@
 package serf
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -40,6 +41,7 @@ func (service *ClusterService) Create(advertiseAddr string, joinAddr []string) e
 
 	conf := serf.DefaultConfig()
 	conf.Init()
+	conf.NodeName = fmt.Sprintf("%s-%s", service.tags[agent.MemberTagKeyNodeName], conf.NodeName)
 	conf.Tags = service.tags
 	conf.MemberlistConfig.LogOutput = filter
 	conf.LogOutput = filter


### PR DESCRIPTION
…st node name

This PR introduce a small change to rename the agent name as exposed by Serf from `container_hostname` hostname (example: `47d78f44b503`) to `node_hostname-container_hostname` (example: `swarmnode1-47d78f44b503`) in order to facilitate the readings of the logs.