### PR TITLE
refactor(http): use server Config.Secured to determine TLS usage

### DIFF
--- a/http/handler/docker/docker_operation.go
+++ b/http/handler/docker/docker_operation.go
@@ -65,7 +65,7 @@ func (handler *Handler) executeOperationOnManagerNode(rw http.ResponseWriter, re
 		if targetMember == nil {
 			return &httperror.HandlerError{http.StatusInternalServerError, "The agent was unable to contact any other agent located on a manager node", errors.New("Unable to find an agent on any manager node")}
 		}
-		proxy.AgentHTTPRequest(rw, request, targetMember)
+		proxy.AgentHTTPRequest(rw, request, targetMember, handler.useTLS)
 	}
 	return nil
 }
@@ -81,7 +81,7 @@ func (handler *Handler) executeOperationOnNode(rw http.ResponseWriter, request *
 			return &httperror.HandlerError{http.StatusInternalServerError, "The agent was unable to contact any other agent", errors.New("Unable to find the targeted agent")}
 		}
 
-		proxy.AgentHTTPRequest(rw, request, targetMember)
+		proxy.AgentHTTPRequest(rw, request, targetMember, handler.useTLS)
 	}
 	return nil
 }

--- a/http/handler/docker/handler.go
+++ b/http/handler/docker/handler.go
@@ -15,15 +15,16 @@ type Handler struct {
 	clusterProxy   *proxy.ClusterProxy
 	clusterService agent.ClusterService
 	agentTags      map[string]string
+	useTLS         bool
 }
 
 // NewHandler returns a new instance of Handler.
 // It sets the associated handle functions for all the Docker related HTTP endpoints.
-func NewHandler(clusterService agent.ClusterService, agentTags map[string]string, notaryService *security.NotaryService) *Handler {
+func NewHandler(clusterService agent.ClusterService, agentTags map[string]string, notaryService *security.NotaryService, useTLS bool) *Handler {
 	h := &Handler{
 		Router:         mux.NewRouter(),
 		dockerProxy:    proxy.NewLocalProxy(),
-		clusterProxy:   proxy.NewClusterProxy(),
+		clusterProxy:   proxy.NewClusterProxy(useTLS),
 		clusterService: clusterService,
 		agentTags:      agentTags,
 	}

--- a/http/handler/handler.go
+++ b/http/handler/handler.go
@@ -52,14 +52,14 @@ var dockerAPIVersionRegexp = regexp.MustCompile(`(/v[0-9]\.[0-9]*)?`)
 
 // NewHandler returns a pointer to a Handler.
 func NewHandler(config *Config) *Handler {
-	agentProxy := proxy.NewAgentProxy(config.ClusterService, config.AgentTags)
+	agentProxy := proxy.NewAgentProxy(config.ClusterService, config.AgentTags, config.Secured)
 	notaryService := security.NewNotaryService(config.SignatureService, config.Secured)
 
 	return &Handler{
 		agentHandler:       httpagenthandler.NewHandler(config.ClusterService, notaryService),
 		browseHandler:      browse.NewHandler(agentProxy, notaryService, config.AgentOptions),
 		browseHandlerV1:    browse.NewHandlerV1(agentProxy, notaryService),
-		dockerProxyHandler: docker.NewHandler(config.ClusterService, config.AgentTags, notaryService),
+		dockerProxyHandler: docker.NewHandler(config.ClusterService, config.AgentTags, notaryService, config.Secured),
 		keyHandler:         key.NewHandler(config.TunnelOperator, config.ClusterService, notaryService, config.EdgeMode),
 		webSocketHandler:   websocket.NewHandler(config.ClusterService, config.AgentTags, notaryService),
 		hostHandler:        host.NewHandler(config.SystemService, agentProxy, notaryService),

--- a/http/proxy/agentproxy.go
+++ b/http/proxy/agentproxy.go
@@ -12,13 +12,15 @@ import (
 type AgentProxy struct {
 	clusterService agent.ClusterService
 	agentTags      map[string]string
+	useTLS         bool
 }
 
 // NewAgentProxy returns a pointer to a new AgentProxy object
-func NewAgentProxy(clusterService agent.ClusterService, agentTags map[string]string) *AgentProxy {
+func NewAgentProxy(clusterService agent.ClusterService, agentTags map[string]string, useTLS bool) *AgentProxy {
 	return &AgentProxy{
 		clusterService: clusterService,
 		agentTags:      agentTags,
+		useTLS:         useTLS,
 	}
 }
 
@@ -40,7 +42,7 @@ func (p *AgentProxy) Redirect(next http.Handler) http.Handler {
 			if targetMember == nil {
 				return &httperror.HandlerError{http.StatusInternalServerError, "The agent was unable to contact any other agent", errors.New("Unable to find the targeted agent")}
 			}
-			AgentHTTPRequest(rw, r, targetMember)
+			AgentHTTPRequest(rw, r, targetMember, p.useTLS)
 		}
 		return nil
 	})

--- a/http/proxy/cluster.go
+++ b/http/proxy/cluster.go
@@ -16,11 +16,12 @@ const defaultClusterRequestTimeout = 120
 // ClusterProxy is a service used to execute the same requests on multiple targets.
 type ClusterProxy struct {
 	client *http.Client
+	useTLS bool
 }
 
 // NewClusterProxy returns a pointer to a ClusterProxy.
 // It also sets the default values used in the underlying http.Client.
-func NewClusterProxy() *ClusterProxy {
+func NewClusterProxy(useTLS bool) *ClusterProxy {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 	}
@@ -32,6 +33,7 @@ func NewClusterProxy() *ClusterProxy {
 				TLSClientConfig: tlsConfig,
 			},
 		},
+		useTLS: useTLS,
 	}
 }
 
@@ -87,7 +89,7 @@ func (clusterProxy *ClusterProxy) executeRequestOnCluster(request *http.Request,
 func (clusterProxy *ClusterProxy) copyAndExecuteRequest(request *http.Request, member *agent.ClusterMember, ch chan agentRequestResult, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	requestCopy, err := copyRequest(request, member)
+	requestCopy, err := copyRequest(request, member, clusterProxy.useTLS)
 	if err != nil {
 		ch <- agentRequestResult{err: err}
 		return
@@ -109,7 +111,7 @@ func (clusterProxy *ClusterProxy) copyAndExecuteRequest(request *http.Request, m
 	ch <- agentRequestResult{err: nil, responseContent: data, nodeName: member.NodeName}
 }
 
-func copyRequest(request *http.Request, member *agent.ClusterMember) (*http.Request, error) {
+func copyRequest(request *http.Request, member *agent.ClusterMember, useTLS bool) (*http.Request, error) {
 	body, err := ioutil.ReadAll(request.Body)
 	if err != nil {
 		return nil, err
@@ -119,7 +121,7 @@ func copyRequest(request *http.Request, member *agent.ClusterMember) (*http.Requ
 	url.Host = member.IPAddress + ":" + member.Port
 
 	url.Scheme = "http"
-	if request.TLS != nil {
+	if useTLS {
 		url.Scheme = "https"
 	}
 

--- a/http/proxy/proxy.go
+++ b/http/proxy/proxy.go
@@ -12,12 +12,12 @@ import (
 )
 
 // AgentHTTPRequest redirects a HTTP request to another agent.
-func AgentHTTPRequest(rw http.ResponseWriter, request *http.Request, target *agent.ClusterMember) {
+func AgentHTTPRequest(rw http.ResponseWriter, request *http.Request, target *agent.ClusterMember, useTLS bool) {
 	urlCopy := request.URL
 	urlCopy.Host = target.IPAddress + ":" + target.Port
 
 	urlCopy.Scheme = "http"
-	if request.TLS != nil {
+	if useTLS {
 		urlCopy.Scheme = "https"
 	}
 


### PR DESCRIPTION
This PR refactor internal request proxy/handling between agents to use the `Config.Secured` field to determine if HTTPS must be used to communicate with other agents instead of relaying on the original request `TLS` field.