### PR TITLE
feat(http): add profiling endpoints

### DIFF
--- a/http/handler/debug/handler.go
+++ b/http/handler/debug/handler.go
@@ -1,0 +1,31 @@
+package debug
+
+import (
+	"net/http/pprof"
+
+	"github.com/gorilla/mux"
+)
+
+// Handler is the HTTP handler used to handle debug operations.
+type Handler struct {
+	*mux.Router
+}
+
+// NewHandler returns a pointer to an Handler
+func NewHandler() *Handler {
+	h := &Handler{
+		Router: mux.NewRouter(),
+	}
+
+	h.HandleFunc("/debug/pprof/", pprof.Index)
+	h.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	h.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	h.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+
+	h.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	h.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	h.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	h.Handle("/debug/pprof/block", pprof.Handler("block"))
+
+	return h
+}

--- a/http/handler/handler.go
+++ b/http/handler/handler.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/portainer/agent/http/handler/debug"
+
 	"github.com/portainer/agent/http/handler/key"
 
 	"github.com/portainer/agent"
@@ -27,6 +29,7 @@ type Handler struct {
 	browseHandler      *browse.Handler
 	browseHandlerV1    *browse.Handler
 	dockerProxyHandler *docker.Handler
+	debugHandler       *debug.Handler
 	keyHandler         *key.Handler
 	webSocketHandler   *websocket.Handler
 	hostHandler        *host.Handler
@@ -60,6 +63,7 @@ func NewHandler(config *Config) *Handler {
 		browseHandler:      browse.NewHandler(agentProxy, notaryService, config.AgentOptions),
 		browseHandlerV1:    browse.NewHandlerV1(agentProxy, notaryService),
 		dockerProxyHandler: docker.NewHandler(config.ClusterService, config.AgentTags, notaryService),
+		debugHandler:       debug.NewHandler(),
 		keyHandler:         key.NewHandler(config.TunnelOperator, config.ClusterService, notaryService, config.EdgeMode),
 		webSocketHandler:   websocket.NewHandler(config.ClusterService, config.AgentTags, notaryService),
 		hostHandler:        host.NewHandler(config.SystemService, agentProxy, notaryService),
@@ -103,6 +107,8 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, request *http.Request) {
 		h.browseHandler.ServeHTTP(rw, request)
 	case strings.HasPrefix(request.URL.Path, "/websocket"):
 		h.webSocketHandler.ServeHTTP(rw, request)
+	case strings.HasPrefix(request.URL.Path, "/debug"):
+		h.debugHandler.ServeHTTP(rw, request)
 	case strings.HasPrefix(request.URL.Path, "/"):
 		h.dockerProxyHandler.ServeHTTP(rw, request)
 	}


### PR DESCRIPTION
Add profiling endpoints to the API that can be used to profile the agent through pprof.

NOTE: The purpose of this PR is to provide a profiling implementation and image through CI, merging it inside the codebase must be discussed in a proper issue. 