### PR TITLE
feat(serf) override serf probe interval and timeout w/ environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ The behavior of the agent can be tuned via a set of mandatory and optional optio
 * AGENT_CLUSTER_ADDR (*mandatory*): address (in the IP:PORT format) of an existing agent to join the agent cluster. When deploying the agent as a Docker Swarm service,
 we can leverage the internal Docker DNS to automatically join existing agents or form a cluster by using `tasks.<AGENT_SERVICE_NAME>:<AGENT_PORT>` as the address.
 * AGENT_PROBE_TIMEOUT (*optional*): timeout interval for receiving agent member probe responses (default to `500ms`)
+* AGENT_PROBE_INTERVAL (*optional*): interval for repeating failed agent member probe (default to `1s`)
 * AGENT_HOST (*optional*): address on which the agent API will be exposed (default to `0.0.0.0`)
 * AGENT_PORT (*optional*): port on which the agent API will be exposed (default to `9001`)
 * CAP_HOST_MANAGEMENT (*optional*): enable advanced filesystem management features. Disabled by default, set to `1` to enable it

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The behavior of the agent can be tuned via a set of mandatory and optional optio
 
 * AGENT_CLUSTER_ADDR (*mandatory*): address (in the IP:PORT format) of an existing agent to join the agent cluster. When deploying the agent as a Docker Swarm service,
 we can leverage the internal Docker DNS to automatically join existing agents or form a cluster by using `tasks.<AGENT_SERVICE_NAME>:<AGENT_PORT>` as the address.
+* AGENT_PROBE_TIMEOUT (*optional*): timeout interval for receiving agent member probe responses (default to `500ms`)
 * AGENT_HOST (*optional*): address on which the agent API will be exposed (default to `0.0.0.0`)
 * AGENT_PORT (*optional*): port on which the agent API will be exposed (default to `9001`)
 * CAP_HOST_MANAGEMENT (*optional*): enable advanced filesystem management features. Disabled by default, set to `1` to enable it

--- a/agent.go
+++ b/agent.go
@@ -1,11 +1,14 @@
 package agent
 
+import "time"
+
 type (
 	// AgentOptions are the options used to start an agent.
 	Options struct {
 		AgentServerAddr       string
 		AgentServerPort       string
 		ClusterAddress        string
+		ProbeTimeout          time.Duration
 		HostManagementEnabled bool
 		SharedSecret          string
 		EdgeMode              bool
@@ -78,7 +81,7 @@ type (
 
 	// ClusterService is used to manage a cluster of agents.
 	ClusterService interface {
-		Create(advertiseAddr string, joinAddr []string) error
+		Create(advertiseAddr string, joinAddr []string, probeTimeout time.Duration) error
 		Members() []ClusterMember
 		Leave()
 		GetMemberByRole(role string) *ClusterMember
@@ -145,6 +148,8 @@ const (
 	DefaultAgentAddr = "0.0.0.0"
 	// DefaultAgentPort is the default port exposed by the Agent API server.
 	DefaultAgentPort = "9001"
+	// DefaultProbeTimeout is the default member list ping probe timeout.
+	DefaultProbeTimeout = 500 * time.Millisecond
 	// DefaultLogLevel is the default logging level.
 	DefaultLogLevel = "INFO"
 	// DefaultEdgeSecurityShutdown is the default time after which the Edge server will shutdown if no key is specified

--- a/agent.go
+++ b/agent.go
@@ -9,6 +9,7 @@ type (
 		AgentServerPort       string
 		ClusterAddress        string
 		ProbeTimeout          time.Duration
+		ProbeInterval         time.Duration
 		HostManagementEnabled bool
 		SharedSecret          string
 		EdgeMode              bool
@@ -81,7 +82,7 @@ type (
 
 	// ClusterService is used to manage a cluster of agents.
 	ClusterService interface {
-		Create(advertiseAddr string, joinAddr []string, probeTimeout time.Duration) error
+		Create(advertiseAddr string, joinAddr []string, probeTimeout time.Duration, probeInterval time.Duration) error
 		Members() []ClusterMember
 		Leave()
 		GetMemberByRole(role string) *ClusterMember
@@ -150,6 +151,8 @@ const (
 	DefaultAgentPort = "9001"
 	// DefaultProbeTimeout is the default member list ping probe timeout.
 	DefaultProbeTimeout = 500 * time.Millisecond
+	// DefaultProbeInterval is the interval for repeating failed node checks.
+	DefaultProbeInterval = 1 * time.Second
 	// DefaultLogLevel is the default logging level.
 	DefaultLogLevel = "INFO"
 	// DefaultEdgeSecurityShutdown is the default time after which the Edge server will shutdown if no key is specified

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -74,12 +74,12 @@ func main() {
 			log.Fatalf("[ERROR] [main,net] [host: %s] [message: Unable to retrieve a list of IP associated to the host] [error: %s]", clusterAddr, err)
 		}
 
-		err = clusterService.Create(advertiseAddr, joinAddr)
+		err = clusterService.Create(advertiseAddr, joinAddr, options.ProbeTimeout)
 		if err != nil {
 			log.Fatalf("[ERROR] [main,cluster] [message: Unable to create cluster] [error: %s]", err)
 		}
 
-		log.Printf("[DEBUG] [main,configuration] [agent_port: %s] [cluster_address: %s] [advertise_address: %s]", options.AgentServerPort, clusterAddr, advertiseAddr)
+		log.Printf("[DEBUG] [main,configuration] [agent_port: %s] [cluster_address: %s] [advertise_address: %s] [probe_timeout: %s]", options.AgentServerPort, clusterAddr, advertiseAddr, options.ProbeTimeout)
 
 		defer clusterService.Leave()
 	}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -74,12 +74,12 @@ func main() {
 			log.Fatalf("[ERROR] [main,net] [host: %s] [message: Unable to retrieve a list of IP associated to the host] [error: %s]", clusterAddr, err)
 		}
 
-		err = clusterService.Create(advertiseAddr, joinAddr, options.ProbeTimeout)
+		err = clusterService.Create(advertiseAddr, joinAddr, options.ProbeTimeout, options.ProbeInterval)
 		if err != nil {
 			log.Fatalf("[ERROR] [main,cluster] [message: Unable to create cluster] [error: %s]", err)
 		}
 
-		log.Printf("[DEBUG] [main,configuration] [agent_port: %s] [cluster_address: %s] [advertise_address: %s] [probe_timeout: %s]", options.AgentServerPort, clusterAddr, advertiseAddr, options.ProbeTimeout)
+		log.Printf("[DEBUG] [main,configuration] [agent_port: %s] [cluster_address: %s] [advertise_address: %s] [probe_timeout: %s] [probe_interval: %s]", options.AgentServerPort, clusterAddr, advertiseAddr, options.ProbeTimeout, options.ProbeInterval)
 
 		defer clusterService.Leave()
 	}

--- a/os/options.go
+++ b/os/options.go
@@ -14,6 +14,7 @@ const (
 	EnvKeyAgentPort             = "AGENT_PORT"
 	EnvKeyClusterAddr           = "AGENT_CLUSTER_ADDR"
 	EnvKeyProbeTimeout          = "AGENT_PROBE_TIMEOUT"
+	EnvKeyProbeInterval         = "AGENT_PROBE_INTERVAL"
 	EnvKeyAgentSecret           = "AGENT_SECRET"
 	EnvKeyCapHostManagement     = "CAP_HOST_MANAGEMENT"
 	EnvKeyEdge                  = "EDGE"
@@ -38,6 +39,7 @@ func (parser *EnvOptionParser) Options() (*agent.Options, error) {
 		AgentServerPort:       agent.DefaultAgentPort,
 		ClusterAddress:        os.Getenv(EnvKeyClusterAddr),
 		ProbeTimeout:          agent.DefaultProbeTimeout,
+		ProbeInterval:         agent.DefaultProbeInterval,
 		HostManagementEnabled: false,
 		SharedSecret:          os.Getenv(EnvKeyAgentSecret),
 		EdgeID:                os.Getenv(EnvKeyEdgeID),
@@ -118,6 +120,15 @@ func (parser *EnvOptionParser) Options() (*agent.Options, error) {
 			return nil, errors.New("invalid time duration format in " + EnvKeyProbeTimeout + " environment variable")
 		}
 		options.ProbeTimeout = timeout
+	}
+
+	probeIntervalEnv := os.Getenv(EnvKeyProbeInterval)
+	if probeIntervalEnv != "" {
+		interval, err := time.ParseDuration(probeIntervalEnv)
+		if err != nil {
+			return nil, errors.New("invalid time duration format in " + EnvKeyProbeInterval + " environment variable")
+		}
+		options.ProbeInterval = interval
 	}
 
 	return options, nil

--- a/os/options.go
+++ b/os/options.go
@@ -13,6 +13,7 @@ const (
 	EnvKeyAgentHost             = "AGENT_HOST"
 	EnvKeyAgentPort             = "AGENT_PORT"
 	EnvKeyClusterAddr           = "AGENT_CLUSTER_ADDR"
+	EnvKeyProbeTimeout          = "AGENT_PROBE_TIMEOUT"
 	EnvKeyAgentSecret           = "AGENT_SECRET"
 	EnvKeyCapHostManagement     = "CAP_HOST_MANAGEMENT"
 	EnvKeyEdge                  = "EDGE"
@@ -36,6 +37,7 @@ func (parser *EnvOptionParser) Options() (*agent.Options, error) {
 		AgentServerAddr:       agent.DefaultAgentAddr,
 		AgentServerPort:       agent.DefaultAgentPort,
 		ClusterAddress:        os.Getenv(EnvKeyClusterAddr),
+		ProbeTimeout:          agent.DefaultProbeTimeout,
 		HostManagementEnabled: false,
 		SharedSecret:          os.Getenv(EnvKeyAgentSecret),
 		EdgeID:                os.Getenv(EnvKeyEdgeID),
@@ -107,6 +109,15 @@ func (parser *EnvOptionParser) Options() (*agent.Options, error) {
 	logLevelEnv := os.Getenv(EnvKeyLogLevel)
 	if logLevelEnv != "" {
 		options.LogLevel = logLevelEnv
+	}
+
+	probeTimeoutEnv := os.Getenv(EnvKeyProbeTimeout)
+	if probeTimeoutEnv != "" {
+		timeout, err := time.ParseDuration(probeTimeoutEnv)
+		if err != nil {
+			return nil, errors.New("invalid time duration format in " + EnvKeyProbeTimeout + " environment variable")
+		}
+		options.ProbeTimeout = timeout
 	}
 
 	return options, nil

--- a/serf/cluster.go
+++ b/serf/cluster.go
@@ -33,7 +33,7 @@ func (service *ClusterService) Leave() {
 }
 
 // Create will create the agent configuration and automatically join the cluster.
-func (service *ClusterService) Create(advertiseAddr string, joinAddr []string) error {
+func (service *ClusterService) Create(advertiseAddr string, joinAddr []string, probeTimeout time.Duration) error {
 	filter := &logutils.LevelFilter{
 		Levels:   []logutils.LogLevel{"DEBUG", "INFO", "WARN", "ERROR"},
 		MinLevel: logutils.LogLevel("INFO"),
@@ -47,6 +47,7 @@ func (service *ClusterService) Create(advertiseAddr string, joinAddr []string) e
 	conf.MemberlistConfig.LogOutput = filter
 	conf.LogOutput = filter
 	conf.MemberlistConfig.AdvertiseAddr = advertiseAddr
+	conf.MemberlistConfig.ProbeTimeout = probeTimeout
 
 	// Override default Serf configuration with Swarm/overlay sane defaults
 	conf.ReconnectInterval = 10 * time.Second

--- a/serf/cluster.go
+++ b/serf/cluster.go
@@ -33,7 +33,7 @@ func (service *ClusterService) Leave() {
 }
 
 // Create will create the agent configuration and automatically join the cluster.
-func (service *ClusterService) Create(advertiseAddr string, joinAddr []string, probeTimeout time.Duration) error {
+func (service *ClusterService) Create(advertiseAddr string, joinAddr []string, probeTimeout time.Duration, probeInterval time.Duration) error {
 	filter := &logutils.LevelFilter{
 		Levels:   []logutils.LogLevel{"DEBUG", "INFO", "WARN", "ERROR"},
 		MinLevel: logutils.LogLevel("INFO"),
@@ -48,6 +48,7 @@ func (service *ClusterService) Create(advertiseAddr string, joinAddr []string, p
 	conf.LogOutput = filter
 	conf.MemberlistConfig.AdvertiseAddr = advertiseAddr
 	conf.MemberlistConfig.ProbeTimeout = probeTimeout
+	conf.MemberlistConfig.ProbeInterval = probeInterval
 
 	// Override default Serf configuration with Swarm/overlay sane defaults
 	conf.ReconnectInterval = 10 * time.Second


### PR DESCRIPTION
This pull request implements an optional mechanism for overriding serf probe interval (default: 1 s) and timeout (default: 0.5 s) via environment variables AGENT_PROBE_INTERVAL and AGENT_PROBE_TIMEOUT.

A little background: I'm running Docker Swarm workers on a network of Raspberry Pis scattered all around the site. Network connectivity to the Pis is reliable _enough_ for a swarm with longer `dispatcher-heartbeat` setting to survive regular network slowdowns, but Portainer Agent, in my case, relies too heavily on refuted suspect messages to keep the other agents connected. Default timeout for receiving acknowledgments from peers is simply too low for such network (bad Wi-fi signal reception + underpowered hardware). Moreover, sometimes even refutes get lost and fall-back TCP ping mechanism does not wait for successful TCP retransmits before deciding the peer is dead. As a consequence, I'm experiencing all the symptoms described in portainer/portainer#2535.

I tracked the instability issues to default (sane) LAN configuration of serf probe in Agent, namely the probe interval and timeout. By running a custom build of Agent where I replaced the Agent's default settings with serf's WAN presets, I got rid of endpoint instability issues completely and my agent logs are much cleaner now. I'm therefore submitting this pull request where probe interval and timeout can be overridden by two environment variables - it may come in handy to people running swarm on poor networks.
