### PR TITLE
feat(agent): Docker node console access

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -1,4 +1,6 @@
 FROM portainer/base
+COPY --from=busybox /bin/busybox /bin/
+COPY bash /bin/
 
 WORKDIR /app
 

--- a/build/linux/bash
+++ b/build/linux/bash
@@ -1,0 +1,11 @@
+#!/bin/busybox sh
+
+if [ -z "$CONSOLE_USER" ]; then
+  export CONSOLE_USER=root
+fi
+
+if [[ "$CAP_HOST_MANAGEMENT" == "1" ]]; then
+  /bin/busybox chroot /host su $CONSOLE_USER
+else
+  echo "Host management is disabled"
+fi


### PR DESCRIPTION
Simple enhancement to host management on way that console opened from Portainer agent container actually open chrooted shell to Docker node.

Only enabled when CAP_HOST_MANAGEMENT=1. Also support console user to be changed to other than root by setting CONSOLE_USER environment variable.

Here is example how it looks:
![image](https://user-images.githubusercontent.com/6213926/75114726-2fae7400-5661-11ea-9434-26981124f085.png)

Test Docker image is available on **ollijanatuinen/portainer-agent:host-console-3**