### PR TITLE
feat(main): continue startup even if edge key failed to load from cluster

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -91,7 +91,7 @@ func main() {
 	if options.EdgeMode {
 		edgeKey, err := retrieveEdgeKey(options.EdgeKey, clusterService)
 		if err != nil {
-			log.Fatalf("[ERROR] [main,edge] [message: Unable to retrieve Edge key] [error: %s]", err)
+			log.Printf("[ERROR] [main,edge] [message: Unable to retrieve Edge key] [error: %s]", err)
 		}
 
 		if edgeKey != "" {


### PR DESCRIPTION
fix #132 