### PR TITLE
chore(project): bump base image for windows

### DIFF
--- a/build/windows/Dockerfile
+++ b/build/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/nanoserver:sac2016
+FROM mcr.microsoft.com/windows/nanoserver:1809-amd64
 
 USER ContainerAdministrator
 

--- a/build/windows/Dockerfile
+++ b/build/windows/Dockerfile
@@ -1,6 +1,9 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as core
 FROM mcr.microsoft.com/windows/nanoserver:1809-amd64
 
 USER ContainerAdministrator
+
+COPY --from=core /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 
 WORKDIR /app
 


### PR DESCRIPTION
bump the base image in the windows dockerfile as it is using an old SAC image
Implements the same change and work-around as https://github.com/portainer/portainer/issues/4043