### PR TITLE
chore(dev): introduce new dev script (CE-427)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,14 +256,19 @@ If you want to add any extra dependency:
 dep ensure -add github.com/foo/bar
 ```
 
-3. Run a local agent container:
+### 3. Run 
+
+- A local agent container:
 
 ```
 ./dev.sh local
 ```
 
-4. Run the agent container inside a Swarm cluster (requires https://github.com/deviantony/vagrant-swarm-cluster)
+- The agent container inside a Swarm cluster (requires https://github.com/deviantony/vagrant-swarm-cluster)
 
 ```
 ./dev.sh swarm
 ```
+
+- The dev script has more commands, you can see them by running `./dev.sh`
+

--- a/dev-scripts/build.sh
+++ b/dev-scripts/build.sh
@@ -1,14 +1,15 @@
+#!/usr/bin/env bash
 
 function build() {
-  local ret_value=""
-  default_image_name
-  DEFAULT_IMAGE_NAME=$ret_value
-
-  local IMAGE_NAME="${1:-$DEFAULT_IMAGE_NAME}"
-  docker rmi -f $IMAGE_NAME || true
-
-  msg "Image build..."
-  docker build --no-cache -t $IMAGE_NAME -f build/linux/Dockerfile .
-
-  msg "Image $IMAGE_NAME is built"
+    local ret_value=""
+    default_image_name
+    DEFAULT_IMAGE_NAME=$ret_value
+    
+    local IMAGE_NAME="${1:-$DEFAULT_IMAGE_NAME}"
+    docker rmi -f "$IMAGE_NAME" || true
+    
+    msg "Image build..."
+    docker build --no-cache -t "$IMAGE_NAME" -f build/linux/Dockerfile .
+    
+    msg "Image $IMAGE_NAME is built"
 }

--- a/dev-scripts/build.sh
+++ b/dev-scripts/build.sh
@@ -1,0 +1,14 @@
+
+function build() {
+  local ret_value=""
+  default_image_name
+  DEFAULT_IMAGE_NAME=$ret_value
+
+  local IMAGE_NAME="${1:-$DEFAULT_IMAGE_NAME}"
+  docker rmi -f $IMAGE_NAME || true
+
+  msg "Image build..."
+  docker build --no-cache -t $IMAGE_NAME -f build/linux/Dockerfile .
+
+  msg "Image $IMAGE_NAME is built"
+}

--- a/dev-scripts/build.sh
+++ b/dev-scripts/build.sh
@@ -3,26 +3,26 @@
 compile=0
 image_name=""
 
-function build() {
+function build_command() {
     parse_build_params "${@:1}"
 
     if [[ "$compile" == "1" ]]; then
         compile
     fi
 
-    docker rmi -f "$image_name" || true
+    build "$image_name"
+}
+
+function build() {
+    docker rmi -f "$1" &>/dev/null || true
 
     msg "Image build..."
-    docker build --no-cache -t "$image_name" -f build/linux/Dockerfile .
+    docker build --no-cache -t "$1" -f build/linux/Dockerfile . &>/dev/null
 
-    msg "Image $image_name is built"
+    msg "Image $1 is built"
 }
 
 function parse_build_params() {
-    if [[ "${1-}" == "" ]]; then
-        usage_build
-    fi
-
     while :; do
         case "${1-}" in
         -h | --help) usage_build ;;

--- a/dev-scripts/compile.sh
+++ b/dev-scripts/compile.sh
@@ -1,0 +1,13 @@
+function compile() {
+  TARGET_DIST=dist/agent
+
+  msg "Compilation..."
+
+  cd cmd/agent
+  GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s'
+  rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+  cd ../..
+  mv cmd/agent/agent $TARGET_DIST
+
+  msg "Agent executable is available on $TARGET_DIST"
+}

--- a/dev-scripts/compile.sh
+++ b/dev-scripts/compile.sh
@@ -1,13 +1,15 @@
+#!/usr/bin/env bash
+
 function compile() {
-  TARGET_DIST=dist/agent
-
-  msg "Compilation..."
-
-  cd cmd/agent
-  GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s'
-  rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
-  cd ../..
-  mv cmd/agent/agent $TARGET_DIST
-
-  msg "Agent executable is available on $TARGET_DIST"
+    TARGET_DIST=dist/agent
+    
+    msg "Compilation..."
+    
+    cd cmd/agent || exit 1
+    GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s'
+    rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+    cd ../..
+    mv cmd/agent/agent $TARGET_DIST
+    
+    msg "Agent executable is available on $TARGET_DIST"
 }

--- a/dev-scripts/compile.sh
+++ b/dev-scripts/compile.sh
@@ -1,15 +1,47 @@
 #!/usr/bin/env bash
 
 function compile() {
-    TARGET_DIST=dist/agent
-    
+    parse_compile_params "${@:1}"
+
+    local TARGET_DIST=dist/agent
+    mkdir -p $TARGET_DIST
+
     msg "Compilation..."
-    
+
     cd cmd/agent || exit 1
     GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s'
-    rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+    rc=$?
+    if [[ $rc != 0 ]]; then exit $rc; fi
     cd ../..
     mv cmd/agent/agent $TARGET_DIST
-    
+
     msg "Agent executable is available on $TARGET_DIST"
+}
+
+function parse_compile_params() {
+    while :; do
+        case "${1-}" in
+        -h | --help) usage_compile ;;
+        -v | --verbose) set -x ;;
+        -?*) die "Unknown option: $1" ;;
+        *) break ;;
+        esac
+        shift
+    done
+
+    return 0
+}
+
+function usage_compile() {
+    cmd="./dev.sh"
+    cat <<EOF
+Usage: $cmd compile [-h] [-v|--verbose]
+
+This script is intended to help with compiling of the agent codebase
+
+Available flags:
+-h, --help              Print this help and exit
+-v, --verbose           Verbose output
+EOF
+    exit
 }

--- a/dev-scripts/compile.sh
+++ b/dev-scripts/compile.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
-function compile() {
+function compile_cmd() {
     parse_compile_params "${@:1}"
 
-    local TARGET_DIST=dist/agent
-    mkdir -p $TARGET_DIST
+    compile
+}
 
+function compile() {
     msg "Compilation..."
+
+    local TARGET_DIST=dist
+    mkdir -p $TARGET_DIST
 
     cd cmd/agent || exit 1
     GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s'
@@ -15,7 +19,7 @@ function compile() {
     cd ../..
     mv cmd/agent/agent $TARGET_DIST
 
-    msg "Agent executable is available on $TARGET_DIST"
+    msg "Agent executable is available on $TARGET_DIST/agent"
 }
 
 function parse_compile_params() {

--- a/dev-scripts/deploy.sh
+++ b/dev-scripts/deploy.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-
 local=0
 swarm=0
 build=0
@@ -12,165 +11,170 @@ edge_key=""
 
 LOG_LEVEL=DEBUG
 
-function parse_params() {
+function parse_deploy_params() {
+    if [[ "${1-}" == "" ]]; then
+        usage_deploy
+    fi
+
     while :; do
         case "${1-}" in
-            -h | --help) usage ;;
-            -v | --verbose) set -x ;;
-            --local) local=1 ;;
-            -s | --swarm) swarm=1 ;;
-            -c | --compile) compile=1 ;;
-            -b | --build) build=1 ;;
-            -e | --edge) edge=1 ;;
-            --edge-id)
-                edge_id=$2
-                shift
+        -h | --help) usage_deploy ;;
+        -v | --verbose) set -x ;;
+        --local) local=1 ;;
+        -s | --swarm) swarm=1 ;;
+        -c | --compile) compile=1 ;;
+        -b | --build) build=1 ;;
+        -e | --edge) edge=1 ;;
+        --edge-id)
+            edge_id=$2
+            shift
             ;;
-            --edge-key)
-                edge_key=$2
-                shift
+        --edge-key)
+            edge_key=$2
+            shift
             ;;
-            --ip)
-                swarm_ips+=("$2")
-                shift
+        --ip)
+            swarm_ips+=("$2")
+            shift
             ;;
-            -?*) die "Unknown option: $1" ;;
-            *) break ;;
+        -?*) die "Unknown option: $1" ;;
+        *) break ;;
         esac
         shift
     done
-    
-    # args=("$@")
-    
-    # # check required params and arguments
-    # [[ -z "${param-}" ]] && die "Missing required parameter: param"
-    # [[ ${#args[@]} -eq 0 ]] && die "Missing script arguments"
-    
-    if [[ ($edge -eq 1) && (-z "${edge_id}") ]];
-    then
+
+    if [[ ($edge -eq 1) && (-z "${edge_id}") ]]; then
         die "Missing edge id"
     fi
-    # echo ips ${swarm_ips[@]}
-    # echo swarm $swarm
-    # echo "local" $local
-    # echo swarm_manager_ip $swarm_manager_ip
+
     return 0
 }
 
-
 function deploy() {
-    parse_params "${@:1}"
+    parse_deploy_params "${@:1}"
     local ret_value=""
-    
+
     default_image_name
     local IMAGE_NAME=$ret_value
-    
-    if [[ "$compile" == "1" ]];
-    then
+
+    if [[ "$compile" == "1" ]]; then
         compile
         build=1
     fi
-    
-    if [[ "$build" == "1" ]];
-    then
+
+    if [[ "$build" == "1" ]]; then
         build "$IMAGE_NAME"
     fi
-    
-    if [[ "$local" == "1" ]];
-    then
+
+    if [[ "$local" == "1" ]]; then
         deploy_local
     fi
-    
-    if [[ "$swarm" == "1" ]];
-    then
+
+    if [[ "$swarm" == "1" ]]; then
         deploy_swarm "${swarm_ips[@]}"
     fi
 }
 
 function deploy_local() {
-    if [[ "$swarm" == "1" ]];
-    then
+    if [[ "$swarm" == "1" ]]; then
         run_swarm
         exit 0
     fi
-    
+
     msg "Running local agent $IMAGE_NAME"
-    
+
     docker rm -f portainer-agent-dev
-    
+
     docker run -d --name portainer-agent-dev \
-    -e LOG_LEVEL=${LOG_LEVEL} \
-    -e EDGE=${edge} \
-    -e EDGE_ID="${edge_id}" \
-    -e EDGE_KEY="${edge_key}" \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /var/lib/docker/volumes:/var/lib/docker/volumes \
-    -v /:/host \
-    -p 9001:9001 \
-    -p 80:80 \
-    "${IMAGE_NAME}"
-    
+        -e LOG_LEVEL=${LOG_LEVEL} \
+        -e EDGE=${edge} \
+        -e EDGE_ID="${edge_id}" \
+        -e EDGE_KEY="${edge_key}" \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v /var/lib/docker/volumes:/var/lib/docker/volumes \
+        -v /:/host \
+        -p 9001:9001 \
+        -p 80:80 \
+        "${IMAGE_NAME}"
+
     docker logs -f portainer-agent-dev
 }
 
-
 function deploy_swarm() {
-    if [ $# -eq 0 ]
-    then
+    if [ $# -eq 0 ]; then
         die "Swarm expects at least manager ip"
     fi
-    
+
     run_swarm "$@"
 }
 
 function run_swarm() {
     local URL_PREFIX=""
-    if [ $# -ne 0 ]
-    then
+    if [ $# -ne 0 ]; then
         URL_PREFIX="-H "${1}:2375""
     fi
-    
+
     local node_ips=()
-    if [ $# -gt 1 ]
-    then
-        node_ips=( "${@:2}" )
+    if [ $# -gt 1 ]; then
+        node_ips=("${@:2}")
     fi
-    
+
     rm "/tmp/portainer-agent.tar" || true
-    
+
     msg "Cleaning..."
     docker "$URL_PREFIX" service rm portainer-agent-dev || true
     docker "$URL_PREFIX" network rm portainer-agent-dev-net || true
-    
-    for node_ip in "${node_ips[@]}";
-    do
+
+    for node_ip in "${node_ips[@]}"; do
         docker -H "${node_ip}:2375" rmi -f "${IMAGE_NAME}" || true
     done
-    
+
     msg "Exporting image to Swarm cluster..."
     docker save "${IMAGE_NAME}" -o "/tmp/portainer-agent.tar"
     docker "$URL_PREFIX" load -i "/tmp/portainer-agent.tar"
-    
-    for node_ip in "${node_ips[@]}";
-    do
+
+    for node_ip in "${node_ips[@]}"; do
         docker -H "${node_ip}:2375" load -i "/tmp/portainer-agent.tar"
     done
-    
-    
+
     docker "$URL_PREFIX" network create --driver overlay portainer-agent-dev-net
     docker "$URL_PREFIX" service create --name portainer-agent-dev \
-    --network portainer-agent-dev-net \
-    -e LOG_LEVEL="${LOG_LEVEL}" \
-    -e EDGE=${edge} \
-    -e EDGE_ID="${edge_id}" \
-    -e EDGE_KEY="${edge_key}" \
-    --mode global \
-    --mount type=bind,src=//var/run/docker.sock,dst=/var/run/docker.sock \
-    --mount type=bind,src=//var/lib/docker/volumes,dst=/var/lib/docker/volumes \
-    --mount type=bind,src=//,dst=/host \
-    --publish target=9001,published=9001 \
-    --publish mode=host,published=80,target=80 \
-    "${IMAGE_NAME}"
-    
+        --network portainer-agent-dev-net \
+        -e LOG_LEVEL="${LOG_LEVEL}" \
+        -e EDGE=${edge} \
+        -e EDGE_ID="${edge_id}" \
+        -e EDGE_KEY="${edge_key}" \
+        --mode global \
+        --mount type=bind,src=//var/run/docker.sock,dst=/var/run/docker.sock \
+        --mount type=bind,src=//var/lib/docker/volumes,dst=/var/lib/docker/volumes \
+        --mount type=bind,src=//,dst=/host \
+        --publish target=9001,published=9001 \
+        --publish mode=host,published=80,target=80 \
+        "${IMAGE_NAME}"
+
     docker "$URL_PREFIX" service logs -f portainer-agent-dev
+}
+
+function usage_deploy() {
+    cmd="./dev.sh"
+    cat <<EOF
+Usage: $cmd deploy [-h] [-v|--verbose] [--local] [-s|--swarm]\
+                       [-c|--compile] [-b|--build] [-e|--edge] [--edge-id=EDGE_ID] [--edge-key=EDGE_KEY] \
+                       [--ip=SWARM_MANAGER_IP] [--ip=SWARM_NODE_IP1] [--ip=SWARM_NODE_IP2]
+
+This script is intended to help with deploying of dev enviroment
+
+Available flags:
+-h, --help              Print this help and exit
+-v, --verbose           Verbose output
+--local                 Deploy to a local docker
+-s, --swarm             Deploy to a swarm cluster
+-c, --compile           Compile the code before deployment (will also build a docker image)
+-b, --build             Build the image before deployment
+-e, --edge              Deploy an edge agent
+--edge-id=EDGE_ID       Set agent edge id to EDGE_ID (required when using -e)
+--edge-key=EDGE_KEY     Set agent edge key to EDGE_KEY
+--ip=IP                 Swarm IP, the first will always be the manager ip
+EOF
+    exit
 }

--- a/dev-scripts/deploy.sh
+++ b/dev-scripts/deploy.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+
+
 local=0
 swarm=0
 build=0
@@ -10,158 +13,157 @@ edge_key=""
 LOG_LEVEL=DEBUG
 
 function parse_params() {
-  while :; do
-    case "${1-}" in
-      -h | --help) usage ;;
-      -v | --verbose) set -x ;;
-      --no-color) NO_COLOR=1 ;;
-      --local) local=1 ;; 
-      -s | --swarm) swarm=1 ;; 
-      -c | --compile) compile=1 ;; 
-      -b | --build) build=1 ;; 
-      -e | --edge) edge=1 ;; 
-      --edge-id)
-        edge_id=$2
+    while :; do
+        case "${1-}" in
+            -h | --help) usage ;;
+            -v | --verbose) set -x ;;
+            --local) local=1 ;;
+            -s | --swarm) swarm=1 ;;
+            -c | --compile) compile=1 ;;
+            -b | --build) build=1 ;;
+            -e | --edge) edge=1 ;;
+            --edge-id)
+                edge_id=$2
+                shift
+            ;;
+            --edge-key)
+                edge_key=$2
+                shift
+            ;;
+            --ip)
+                swarm_ips+=("$2")
+                shift
+            ;;
+            -?*) die "Unknown option: $1" ;;
+            *) break ;;
+        esac
         shift
-        ;;
-      --edge-key)
-        edge_key=$2
-        shift
-        ;;
-      --ip)
-        swarm_ips+=($2) 
-        shift 
-        ;;
-      -?*) die "Unknown option: $1" ;;
-      *) break ;;
-    esac
-    shift
-  done
-
-  # args=("$@")
-  
-  # # check required params and arguments
-  # [[ -z "${param-}" ]] && die "Missing required parameter: param"
-  # [[ ${#args[@]} -eq 0 ]] && die "Missing script arguments"
-
-  if [[ ($edge -eq 1) && (-z "${edge_id}") ]];
-  then
-    die "Missing edge id"
-  fi
-  # echo ips ${swarm_ips[@]}
-  # echo swarm $swarm
-  # echo "local" $local
-  # echo swarm_manager_ip $swarm_manager_ip
-  return 0
+    done
+    
+    # args=("$@")
+    
+    # # check required params and arguments
+    # [[ -z "${param-}" ]] && die "Missing required parameter: param"
+    # [[ ${#args[@]} -eq 0 ]] && die "Missing script arguments"
+    
+    if [[ ($edge -eq 1) && (-z "${edge_id}") ]];
+    then
+        die "Missing edge id"
+    fi
+    # echo ips ${swarm_ips[@]}
+    # echo swarm $swarm
+    # echo "local" $local
+    # echo swarm_manager_ip $swarm_manager_ip
+    return 0
 }
 
 
 function deploy() {
-  parse_params ${@:2}
-  local ret_value=""
-
-  default_image_name
-  local IMAGE_NAME=$ret_value
-
-  if [[ "$compile" == "1" ]];
-  then
-    compile
-    build=1
-  fi
-
-  if [[ "$build" == "1" ]];
-  then
-    build $IMAGE_NAME
-  fi
-
-  if [[ "$local" == "1" ]];
-  then
-    deploy_local
-  fi
-
-  if [[ "$swarm" == "1" ]];
-  then
-    deploy_swarm ${swarm_ips[@]}
-  fi
+    parse_params "${@:1}"
+    local ret_value=""
+    
+    default_image_name
+    local IMAGE_NAME=$ret_value
+    
+    if [[ "$compile" == "1" ]];
+    then
+        compile
+        build=1
+    fi
+    
+    if [[ "$build" == "1" ]];
+    then
+        build "$IMAGE_NAME"
+    fi
+    
+    if [[ "$local" == "1" ]];
+    then
+        deploy_local
+    fi
+    
+    if [[ "$swarm" == "1" ]];
+    then
+        deploy_swarm "${swarm_ips[@]}"
+    fi
 }
 
 function deploy_local() {
-  if [[ "$swarm" == "1" ]];
-  then
-    run_swarm
-    exit 0
-  fi 
-
-  msg "Running local agent $IMAGE_NAME"
-
-  docker rm -f portainer-agent-dev
-
-  docker run -d --name portainer-agent-dev \
+    if [[ "$swarm" == "1" ]];
+    then
+        run_swarm
+        exit 0
+    fi
+    
+    msg "Running local agent $IMAGE_NAME"
+    
+    docker rm -f portainer-agent-dev
+    
+    docker run -d --name portainer-agent-dev \
     -e LOG_LEVEL=${LOG_LEVEL} \
     -e EDGE=${edge} \
-    -e EDGE_ID=${edge_id} \
-    -e EDGE_KEY=${edge_key} \
+    -e EDGE_ID="${edge_id}" \
+    -e EDGE_KEY="${edge_key}" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /var/lib/docker/volumes:/var/lib/docker/volumes \
     -v /:/host \
     -p 9001:9001 \
     -p 80:80 \
     "${IMAGE_NAME}"
-
-  docker logs -f portainer-agent-dev
+    
+    docker logs -f portainer-agent-dev
 }
 
 
 function deploy_swarm() {
-  if [ $# -eq 0 ]
-  then
-    die "Swarm expects at least manager ip"
-  fi
-  
-  run_swarm $@
+    if [ $# -eq 0 ]
+    then
+        die "Swarm expects at least manager ip"
+    fi
+    
+    run_swarm "$@"
 }
 
 function run_swarm() {
-  local URL_PREFIX=""
-  if [ $# -ne 0 ]
-  then
-    URL_PREFIX="-H "${1}:2375""
-  fi
-
-  local node_ips=()
-  if [ $# -gt 1 ]
-  then
-    node_ips=${@:2}
-  fi
-
-  rm "/tmp/portainer-agent.tar" || true
-
-  msg "Cleaning..."
-  docker $URL_PREFIX service rm portainer-agent-dev || true
-  docker $URL_PREFIX network rm portainer-agent-dev-net || true
-
-  for node_ip in ${node_ips[@]};
-  do
-    docker -H "${node_ip}:2375" rmi -f "${IMAGE_NAME}" || true
-  done
-
-  msg "Exporting image to Swarm cluster..."
-  docker save "${IMAGE_NAME}" -o "/tmp/portainer-agent.tar"
-  docker $URL_PREFIX load -i "/tmp/portainer-agent.tar"
-
-  for node_ip in ${node_ips[@]};
-  do
-    docker -H "${node_ip}:2375" load -i "/tmp/portainer-agent.tar"
-  done
-  
-
-  docker $URL_PREFIX network create --driver overlay portainer-agent-dev-net
-  docker $URL_PREFIX service create --name portainer-agent-dev \
+    local URL_PREFIX=""
+    if [ $# -ne 0 ]
+    then
+        URL_PREFIX="-H "${1}:2375""
+    fi
+    
+    local node_ips=()
+    if [ $# -gt 1 ]
+    then
+        node_ips=( "${@:2}" )
+    fi
+    
+    rm "/tmp/portainer-agent.tar" || true
+    
+    msg "Cleaning..."
+    docker "$URL_PREFIX" service rm portainer-agent-dev || true
+    docker "$URL_PREFIX" network rm portainer-agent-dev-net || true
+    
+    for node_ip in "${node_ips[@]}";
+    do
+        docker -H "${node_ip}:2375" rmi -f "${IMAGE_NAME}" || true
+    done
+    
+    msg "Exporting image to Swarm cluster..."
+    docker save "${IMAGE_NAME}" -o "/tmp/portainer-agent.tar"
+    docker "$URL_PREFIX" load -i "/tmp/portainer-agent.tar"
+    
+    for node_ip in "${node_ips[@]}";
+    do
+        docker -H "${node_ip}:2375" load -i "/tmp/portainer-agent.tar"
+    done
+    
+    
+    docker "$URL_PREFIX" network create --driver overlay portainer-agent-dev-net
+    docker "$URL_PREFIX" service create --name portainer-agent-dev \
     --network portainer-agent-dev-net \
     -e LOG_LEVEL="${LOG_LEVEL}" \
     -e EDGE=${edge} \
-    -e EDGE_ID=${edge_id} \
-    -e EDGE_KEY=${edge_key} \
+    -e EDGE_ID="${edge_id}" \
+    -e EDGE_KEY="${edge_key}" \
     --mode global \
     --mount type=bind,src=//var/run/docker.sock,dst=/var/run/docker.sock \
     --mount type=bind,src=//var/lib/docker/volumes,dst=/var/lib/docker/volumes \
@@ -169,6 +171,6 @@ function run_swarm() {
     --publish target=9001,published=9001 \
     --publish mode=host,published=80,target=80 \
     "${IMAGE_NAME}"
-
-  docker $URL_PREFIX service logs -f portainer-agent-dev
+    
+    docker "$URL_PREFIX" service logs -f portainer-agent-dev
 }

--- a/dev-scripts/deploy.sh
+++ b/dev-scripts/deploy.sh
@@ -1,0 +1,174 @@
+local=0
+swarm=0
+build=0
+compile=0
+swarm_ips=()
+edge=0
+edge_id=""
+edge_key=""
+
+LOG_LEVEL=DEBUG
+
+function parse_params() {
+  while :; do
+    case "${1-}" in
+      -h | --help) usage ;;
+      -v | --verbose) set -x ;;
+      --no-color) NO_COLOR=1 ;;
+      --local) local=1 ;; 
+      -s | --swarm) swarm=1 ;; 
+      -c | --compile) compile=1 ;; 
+      -b | --build) build=1 ;; 
+      -e | --edge) edge=1 ;; 
+      --edge-id)
+        edge_id=$2
+        shift
+        ;;
+      --edge-key)
+        edge_key=$2
+        shift
+        ;;
+      --ip)
+        swarm_ips+=($2) 
+        shift 
+        ;;
+      -?*) die "Unknown option: $1" ;;
+      *) break ;;
+    esac
+    shift
+  done
+
+  # args=("$@")
+  
+  # # check required params and arguments
+  # [[ -z "${param-}" ]] && die "Missing required parameter: param"
+  # [[ ${#args[@]} -eq 0 ]] && die "Missing script arguments"
+
+  if [[ ($edge -eq 1) && (-z "${edge_id}") ]];
+  then
+    die "Missing edge id"
+  fi
+  # echo ips ${swarm_ips[@]}
+  # echo swarm $swarm
+  # echo "local" $local
+  # echo swarm_manager_ip $swarm_manager_ip
+  return 0
+}
+
+
+function deploy() {
+  parse_params ${@:2}
+  local ret_value=""
+
+  default_image_name
+  local IMAGE_NAME=$ret_value
+
+  if [[ "$compile" == "1" ]];
+  then
+    compile
+    build=1
+  fi
+
+  if [[ "$build" == "1" ]];
+  then
+    build $IMAGE_NAME
+  fi
+
+  if [[ "$local" == "1" ]];
+  then
+    deploy_local
+  fi
+
+  if [[ "$swarm" == "1" ]];
+  then
+    deploy_swarm ${swarm_ips[@]}
+  fi
+}
+
+function deploy_local() {
+  if [[ "$swarm" == "1" ]];
+  then
+    run_swarm
+    exit 0
+  fi 
+
+  msg "Running local agent $IMAGE_NAME"
+
+  docker rm -f portainer-agent-dev
+
+  docker run -d --name portainer-agent-dev \
+    -e LOG_LEVEL=${LOG_LEVEL} \
+    -e EDGE=${edge} \
+    -e EDGE_ID=${edge_id} \
+    -e EDGE_KEY=${edge_key} \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /var/lib/docker/volumes:/var/lib/docker/volumes \
+    -v /:/host \
+    -p 9001:9001 \
+    -p 80:80 \
+    "${IMAGE_NAME}"
+
+  docker logs -f portainer-agent-dev
+}
+
+
+function deploy_swarm() {
+  if [ $# -eq 0 ]
+  then
+    die "Swarm expects at least manager ip"
+  fi
+  
+  run_swarm $@
+}
+
+function run_swarm() {
+  local URL_PREFIX=""
+  if [ $# -ne 0 ]
+  then
+    URL_PREFIX="-H "${1}:2375""
+  fi
+
+  local node_ips=()
+  if [ $# -gt 1 ]
+  then
+    node_ips=${@:2}
+  fi
+
+  rm "/tmp/portainer-agent.tar" || true
+
+  msg "Cleaning..."
+  docker $URL_PREFIX service rm portainer-agent-dev || true
+  docker $URL_PREFIX network rm portainer-agent-dev-net || true
+
+  for node_ip in ${node_ips[@]};
+  do
+    docker -H "${node_ip}:2375" rmi -f "${IMAGE_NAME}" || true
+  done
+
+  msg "Exporting image to Swarm cluster..."
+  docker save "${IMAGE_NAME}" -o "/tmp/portainer-agent.tar"
+  docker $URL_PREFIX load -i "/tmp/portainer-agent.tar"
+
+  for node_ip in ${node_ips[@]};
+  do
+    docker -H "${node_ip}:2375" load -i "/tmp/portainer-agent.tar"
+  done
+  
+
+  docker $URL_PREFIX network create --driver overlay portainer-agent-dev-net
+  docker $URL_PREFIX service create --name portainer-agent-dev \
+    --network portainer-agent-dev-net \
+    -e LOG_LEVEL="${LOG_LEVEL}" \
+    -e EDGE=${edge} \
+    -e EDGE_ID=${edge_id} \
+    -e EDGE_KEY=${edge_key} \
+    --mode global \
+    --mount type=bind,src=//var/run/docker.sock,dst=/var/run/docker.sock \
+    --mount type=bind,src=//var/lib/docker/volumes,dst=/var/lib/docker/volumes \
+    --mount type=bind,src=//,dst=/host \
+    --publish target=9001,published=9001 \
+    --publish mode=host,published=80,target=80 \
+    "${IMAGE_NAME}"
+
+  docker $URL_PREFIX service logs -f portainer-agent-dev
+}

--- a/dev-scripts/deploy.sh
+++ b/dev-scripts/deploy.sh
@@ -159,8 +159,8 @@ function usage_deploy() {
     cmd="./dev.sh"
     cat <<EOF
 Usage: $cmd deploy [-h] [-v|--verbose] [--local] [-s|--swarm]\
-                       [-c|--compile] [-b|--build] [-e|--edge] [--edge-id=EDGE_ID] [--edge-key=EDGE_KEY] \
-                       [--ip=SWARM_MANAGER_IP] [--ip=SWARM_NODE_IP1] [--ip=SWARM_NODE_IP2]
+        [-c|--compile] [-b|--build] [-e|--edge] [--edge-id EDGE_ID] [--edge-key EDGE_KEY] \
+        [--ip SWARM_MANAGER_IP] [--ip SWARM_NODE_IP1] [--ip SWARM_NODE_IP2]
 
 This script is intended to help with deploying of dev enviroment
 
@@ -172,9 +172,9 @@ Available flags:
 -c, --compile           Compile the code before deployment (will also build a docker image)
 -b, --build             Build the image before deployment
 -e, --edge              Deploy an edge agent
---edge-id=EDGE_ID       Set agent edge id to EDGE_ID (required when using -e)
---edge-key=EDGE_KEY     Set agent edge key to EDGE_KEY
---ip=IP                 Swarm IP, the first will always be the manager ip
+--edge-id EDGE_ID       Set agent edge id to EDGE_ID (required when using -e)
+--edge-key EDGE_KEY     Set agent edge key to EDGE_KEY
+--ip IP                 Swarm IP, the first will always be the manager ip
 EOF
     exit
 }

--- a/dev-scripts/deploy.sh
+++ b/dev-scripts/deploy.sh
@@ -11,51 +11,17 @@ edge_key=""
 
 LOG_LEVEL=DEBUG
 
-function parse_deploy_params() {
-    if [[ "${1-}" == "" ]]; then
-        usage_deploy
-    fi
-
-    while :; do
-        case "${1-}" in
-        -h | --help) usage_deploy ;;
-        -v | --verbose) set -x ;;
-        --local) local=1 ;;
-        -s | --swarm) swarm=1 ;;
-        -c | --compile) compile=1 ;;
-        -b | --build) build=1 ;;
-        -e | --edge) edge=1 ;;
-        --edge-id)
-            edge_id=$2
-            shift
-            ;;
-        --edge-key)
-            edge_key=$2
-            shift
-            ;;
-        --ip)
-            swarm_ips+=("$2")
-            shift
-            ;;
-        -?*) die "Unknown option: $1" ;;
-        *) break ;;
-        esac
-        shift
-    done
-
-    if [[ ($edge -eq 1) && (-z "${edge_id}") ]]; then
-        die "Missing edge id"
-    fi
-
-    return 0
-}
-
-function deploy() {
+function deploy_command() {
     parse_deploy_params "${@:1}"
     local ret_value=""
 
     default_image_name
     local IMAGE_NAME=$ret_value
+
+    deploy
+}
+
+function deploy() {
 
     if [[ "$compile" == "1" ]]; then
         compile
@@ -155,11 +121,53 @@ function run_swarm() {
     docker "$URL_PREFIX" service logs -f portainer-agent-dev
 }
 
+function parse_deploy_params() {
+    if [[ "${1-}" == "" ]]; then
+        usage_deploy
+    fi
+
+    while :; do
+        case "${1-}" in
+        -h | --help) usage_deploy ;;
+        -v | --verbose)
+            msg "verbose"
+            set -x
+            ;;
+        --local) local=1 ;;
+        -s | --swarm) swarm=1 ;;
+        -c | --compile) compile=1 ;;
+        -b | --build) build=1 ;;
+        -e | --edge) edge=1 ;;
+        --edge-id)
+            edge_id=$2
+            shift
+            ;;
+        --edge-key)
+            edge_key=$2
+            shift
+            ;;
+        --ip)
+            swarm_ips+=("$2")
+            shift
+            ;;
+        -?*) die "Unknown option: $1" ;;
+        *) break ;;
+        esac
+        shift
+    done
+
+    if [[ ($edge -eq 1) && (-z "${edge_id}") ]]; then
+        die "Missing edge id"
+    fi
+
+    return 0
+}
+
 function usage_deploy() {
     cmd="./dev.sh"
     cat <<EOF
-Usage: $cmd deploy [-h] [-v|--verbose] [--local] [-s|--swarm]\
-        [-c|--compile] [-b|--build] [-e|--edge] [--edge-id EDGE_ID] [--edge-key EDGE_KEY] \
+Usage: $cmd deploy [-h] [-v|--verbose] [--local] [-s|--swarm] 
+        [-c|--compile] [-b|--build] [-e|--edge] [--edge-id EDGE_ID] [--edge-key EDGE_KEY] 
         [--ip SWARM_MANAGER_IP] [--ip SWARM_NODE_IP1] [--ip SWARM_NODE_IP2]
 
 This script is intended to help with deploying of dev enviroment

--- a/dev-scripts/utils.sh
+++ b/dev-scripts/utils.sh
@@ -1,0 +1,24 @@
+function setup_colors() {
+  if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
+    NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
+  else
+    NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
+  fi
+}
+
+function msg() {
+  echo >&2 -e "${1-}"
+}
+
+function die() {
+  local msg=$1
+  local code=${2-1} # default exit status 1
+  msg "$msg"
+  exit "$code"
+}
+
+function default_image_name() {
+  GIT_COMMIT_HASH=`git rev-parse --short HEAD`
+  GIT_BRANCH_NAME=`git rev-parse --abbrev-ref HEAD`
+  ret_value="portainerci/agent:${GIT_BRANCH_NAME//\//-}-${GIT_COMMIT_HASH}"
+}

--- a/dev-scripts/utils.sh
+++ b/dev-scripts/utils.sh
@@ -1,24 +1,26 @@
+#!/usr/bin/env bash
+
 function setup_colors() {
-  if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
-    NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
-  else
-    NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
-  fi
+    if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
+        NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
+    else
+        NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
+    fi
 }
 
 function msg() {
-  echo >&2 -e "${1-}"
+    echo >&2 -e "${1-}"
 }
 
 function die() {
-  local msg=$1
-  local code=${2-1} # default exit status 1
-  msg "$msg"
-  exit "$code"
+    local msg=$1
+    local code=${2-1} # default exit status 1
+    msg "$msg"
+    exit "$code"
 }
 
 function default_image_name() {
-  GIT_COMMIT_HASH=`git rev-parse --short HEAD`
-  GIT_BRANCH_NAME=`git rev-parse --abbrev-ref HEAD`
-  ret_value="portainerci/agent:${GIT_BRANCH_NAME//\//-}-${GIT_COMMIT_HASH}"
+    GIT_COMMIT_HASH=$(git rev-parse --short HEAD)
+    GIT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+    ret_value="portainerci/agent:${GIT_BRANCH_NAME//\//-}-${GIT_COMMIT_HASH}"
 }

--- a/dev.sh
+++ b/dev.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 
 trap cleanup SIGINT SIGTERM ERR EXIT
 
-script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+# script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 source ./dev-scripts/utils.sh
 source ./dev-scripts/compile.sh
@@ -13,44 +13,31 @@ source ./dev-scripts/deploy.sh
 
 usage() {
   cat <<EOF
-Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-v] [-f] -p param_value arg1 [arg2...]
+Usage: $(basename "${BASH_SOURCE[0]}") [-h]
 
 Script description here.
 
 Available options:
 
 -h, --help      Print this help and exit
--v, --verbose   Print script debug info
--f, --flag      Some flag description
--p, --param     Some param description
+TODO
 EOF
-  exit
+    exit
 }
 
+# script cleanup here
 cleanup() {
-  trap - SIGINT SIGTERM ERR EXIT
-  # script cleanup here
+    trap - SIGINT SIGTERM ERR EXIT
 }
 
 
-# parse_params "$@"
-# cmd=$1
-# parse_params ${@:1}
 setup_colors
 
-# script logic here
-
-# msg "${RED}Read parameters:${NOFORMAT}"
-# msg "cmd: ${cmd}"
-# msg "- flag: ${flag}"
-# msg "- param: ${param}"
-# msg "- arguments: ${args[*]-}"
-
 case $1 in
-compile | build | deploy)
-    $1 ${@:1}
-  ;;
-help | usage | *)
-  usage
-  ;;
+    compile | build | deploy)
+        $1 "${@:2}"
+    ;;
+    help | usage | *)
+        usage
+    ;;
 esac

--- a/dev.sh
+++ b/dev.sh
@@ -23,6 +23,8 @@ Available commands:
 compile   Compile the codebase
 build     Build a docker image
 deploy    Deploy the agent image
+local     Compile, build and deploy a local standalone agent
+swarm     Compile, build and deploy a swarm agent
 
 To get help with a command use: $cmd command -h
 

--- a/dev.sh
+++ b/dev.sh
@@ -12,8 +12,8 @@ source ./dev-scripts/build.sh
 source ./dev-scripts/deploy.sh
 
 usage() {
-  cmd=$(basename "${BASH_SOURCE[0]}")
-  cat <<EOF
+    cmd=$(basename "${BASH_SOURCE[0]}")
+    cat <<EOF
 Usage: $cmd command
 
 This script is intended to help with compiling and deploying of dev enviroment
@@ -36,14 +36,19 @@ cleanup() {
     trap - SIGINT SIGTERM ERR EXIT
 }
 
-
 setup_colors
 
 case $1 in
-    compile | build | deploy)
-        $1 "${@:2}"
+compile | build | deploy)
+    "$1"_command "${@:2}"
     ;;
-    help | usage | *)
-        usage
+help | usage)
+    usage
+    ;;
+local)
+    deploy_command --local -c "${@:2}"
+    ;;
+*)
+    deploy_command -s --ip 10.0.7.10 --ip 10.0.7.11 -c "${@:2}"
     ;;
 esac

--- a/dev.sh
+++ b/dev.sh
@@ -1,123 +1,56 @@
 #!/usr/bin/env bash
 
-LOG_LEVEL=DEBUG
-EDGE=1
-TMP="/tmp"
-GIT_COMMIT_HASH=`git rev-parse --short HEAD`
-GIT_BRANCH_NAME=`git rev-parse --abbrev-ref HEAD`
-IMAGE_NAME="portainerci/agent:${GIT_BRANCH_NAME}-${GIT_COMMIT_HASH}"
+set -Eeuo pipefail
 
+trap cleanup SIGINT SIGTERM ERR EXIT
 
-MODE="swarm"
-if [[ $# -gt 0 ]] ; then
-  MODE=$1
-fi
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
-SKIP_COMPILE=false
-if [[ $# -eq 2 ]] ; then
- SKIP_COMPILE=true
-fi
+source ./dev-scripts/utils.sh
+source ./dev-scripts/compile.sh
+source ./dev-scripts/build.sh
+source ./dev-scripts/deploy.sh
 
-if [[ "${MODE}" == 'help' ]]; then
-  echo "Usage: $(basename $0) <MODE:local/swarm> <SKIP_COMPILE:true/false>"
-  exit 0
-fi
+usage() {
+  cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-v] [-f] -p param_value arg1 [arg2...]
 
-function compile() {
-  echo "Compilation..."
+Script description here.
 
-  cd cmd/agent
-  GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s'
-  rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
-  cd ../..
-  mv cmd/agent/agent dist/agent
+Available options:
 
+-h, --help      Print this help and exit
+-v, --verbose   Print script debug info
+-f, --flag      Some flag description
+-p, --param     Some param description
+EOF
+  exit
 }
 
-function deploy_local() {
-  EDGE_ID="4657f071-8a19-4102-abb6-02ddb8cf3468" # generated via uuidgen
-
-  echo "Cleanup previous settings..."
-  docker rm -f portainer-agent-dev
-  docker rmi "${IMAGE_NAME}"
-
-  echo "Image build..."
-  docker build --no-cache -t "${IMAGE_NAME}" -f build/linux/Dockerfile .
-
-  echo "Deployment..."
-  docker run -d --name portainer-agent-dev \
-  -e LOG_LEVEL=${LOG_LEVEL} \
-  -e EDGE=${EDGE} \
-  -e EDGE_ID=${EDGE_ID} \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v /var/lib/docker/volumes:/var/lib/docker/volumes \
-  -v /:/host \
-  -p 9001:9001 \
-  -p 80:80 \
-  "${IMAGE_NAME}"
-
-  docker logs -f portainer-agent-dev
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  # script cleanup here
 }
 
-function deploy_swarm() {
-  DOCKER_MANAGER=tcp://10.0.7.10
-  DOCKER_NODE=tcp://10.0.7.11
-  #  DOCKER_NODE2=tcp://10.0.7.12
-  EDGE_ID="a1a1c817-7f89-43b1-97e5-508d96c00be9" # generated via uuidgen
 
+# parse_params "$@"
+# cmd=$1
+# parse_params ${@:1}
+setup_colors
 
-  echo "Cleanup previous settings..."
+# script logic here
 
-  rm "${TMP}/portainer-agent.tar"
+# msg "${RED}Read parameters:${NOFORMAT}"
+# msg "cmd: ${cmd}"
+# msg "- flag: ${flag}"
+# msg "- param: ${param}"
+# msg "- arguments: ${args[*]-}"
 
-  docker -H "${DOCKER_MANAGER}:2375" service rm portainer-agent-dev
-  docker -H "${DOCKER_MANAGER}:2375" network rm portainer-agent-dev-net
-  docker -H "${DOCKER_MANAGER}:2375" rmi -f "${IMAGE_NAME}"
-  docker -H "${DOCKER_NODE}:2375" rmi -f "${IMAGE_NAME}"
-  #  docker -H "${DOCKER_NODE2}:2375" rmi -f "${IMAGE_NAME}"
-
-  echo "Building image locally and exporting to Swarm cluster..."
-  docker build --no-cache -t "${IMAGE_NAME}" -f build/linux/Dockerfile .
-  docker save "${IMAGE_NAME}" -o "${TMP}/portainer-agent.tar"
-  docker -H "${DOCKER_MANAGER}:2375" load -i "${TMP}/portainer-agent.tar"
-  docker -H "${DOCKER_NODE}:2375" load -i "${TMP}/portainer-agent.tar"
-  #  docker -H "${DOCKER_NODE2}:2375" load -i "${TMP}/portainer-agent.tar"
-
-  echo "Sleep..."
-  sleep 5
-
-  echo "Deployment..."
-
-  docker -H "${DOCKER_MANAGER}:2375" network create --driver overlay portainer-agent-dev-net
-  docker -H "${DOCKER_MANAGER}:2375" service create --name portainer-agent-dev \
-  --network portainer-agent-dev-net \
-  -e LOG_LEVEL="${LOG_LEVEL}" \
-  -e EDGE=${EDGE} \
-  -e EDGE_ID=${EDGE_ID} \
-  --mode global \
-  --mount type=bind,src=//var/run/docker.sock,dst=/var/run/docker.sock \
-  --mount type=bind,src=//var/lib/docker/volumes,dst=/var/lib/docker/volumes \
-  --mount type=bind,src=//,dst=/host \
-  --publish target=9001,published=9001 \
-  --publish mode=host,published=80,target=80 \
-  "${IMAGE_NAME}"
-
-  #  --mount type=volume,src=portainer_agent_data,dst=/data \
-
-  docker -H "${DOCKER_MANAGER}:2375" service logs -f portainer-agent-dev
-}
-
-function main() {
-  if [[ $SKIP_COMPILE == false ]]; then
-    compile
-  fi
-
-  if [[ "${MODE}" == 'local' ]]; then
-    deploy_local
-  else
-    # Only to be used with deviantony/vagrant-swarm-cluster.git
-    deploy_swarm
-  fi
-}
-
-main
+case $1 in
+compile | build | deploy)
+    $1 ${@:1}
+  ;;
+help | usage | *)
+  usage
+  ;;
+esac

--- a/dev.sh
+++ b/dev.sh
@@ -20,7 +20,6 @@ This script is intended to help with compiling and deploying of dev enviroment
 
 Available commands:
 
-help      Print this help and exit
 compile   Compile the codebase
 build     Build a docker image
 deploy    Deploy the agent image
@@ -38,17 +37,21 @@ cleanup() {
 
 setup_colors
 
+if [[ "${1-}" == "" ]]; then
+    usage
+fi
+
 case $1 in
 compile | build | deploy)
     "$1"_command "${@:2}"
     ;;
-help | usage | -h)
-    usage
-    ;;
 local)
     deploy_command --local -c "${@:2}"
     ;;
-*)
+swarm)
     deploy_command -s --ip 10.0.7.10 --ip 10.0.7.11 -c "${@:2}"
+    ;;
+*)
+    usage
     ;;
 esac

--- a/dev.sh
+++ b/dev.sh
@@ -42,7 +42,7 @@ case $1 in
 compile | build | deploy)
     "$1"_command "${@:2}"
     ;;
-help | usage)
+help | usage | -h)
     usage
     ;;
 local)

--- a/dev.sh
+++ b/dev.sh
@@ -12,15 +12,21 @@ source ./dev-scripts/build.sh
 source ./dev-scripts/deploy.sh
 
 usage() {
+  cmd=$(basename "${BASH_SOURCE[0]}")
   cat <<EOF
-Usage: $(basename "${BASH_SOURCE[0]}") [-h]
+Usage: $cmd command
 
-Script description here.
+This script is intended to help with compiling and deploying of dev enviroment
 
-Available options:
+Available commands:
 
--h, --help      Print this help and exit
-TODO
+help      Print this help and exit
+compile   Compile the codebase
+build     Build a docker image
+deploy    Deploy the agent image
+
+To get help with a command use: $cmd command -h
+
 EOF
     exit
 }


### PR DESCRIPTION
related to #124 
fix [CE-427]

adds a few commands to dev scripts: `deploy`, `build`, `compile`
- `compile` - compiles the code - no parameters
- `build` - builds an image - code should be compiled. takes an optional parameter of image name (if not supplied will use the default `portainerci/agent:${GIT_BRANCH_NAME//\//-}-${GIT_COMMIT_HASH}` where slashes are replaced with `-`
- `deploy` - deploys the code. can take some flags like `--local` for deploying locally, and `--swarm` for deploying to a swarm. when using a not local swarm, should supply also at least one `--ip IP` flag, where the first will be the master.


TODO:
- [x] write usage (--help flag)
- [x] add a flag to build `-c` to compile the image
- [x] add some defaults. `./dev.sh` should compile and deploy to swarm with the vagrant setup, `./dev.sh local` should compile and deploy to local

[CE-427]: https://portainer.atlassian.net/browse/CE-427