### PR TITLE
Adds support for running the agent with podman as container management system

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -253,10 +253,10 @@ const (
 	_ ContainerPlatform = iota
 	// PlatformDocker represent the Docker platform (Standalone/Swarm)
 	PlatformDocker
-	// PlatformDocker represent the Podman platform (Standalone)
-	PlatformPodman
 	// PlatformKubernetes represent the Kubernetes platform
 	PlatformKubernetes
+	// PlatformPodman represent the Podman platform (Standalone)
+	PlatformPodman
 )
 
 const (

--- a/agent.go
+++ b/agent.go
@@ -253,6 +253,8 @@ const (
 	_ ContainerPlatform = iota
 	// PlatformDocker represent the Docker platform (Standalone/Swarm)
 	PlatformDocker
+	// PlatformDocker represent the Podman platform (Standalone)
+	PlatformPodman
 	// PlatformKubernetes represent the Kubernetes platform
 	PlatformKubernetes
 )

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-
 	"log"
 	"time"
 
@@ -73,7 +72,7 @@ func main() {
 		advertiseAddr, err = dockerInfoService.GetContainerIpFromDockerEngine(containerName, clusterMode)
 		if err != nil {
 			if containerPlatform == agent.PlatformPodman {
-				log.Printf("[WARN] [main,docker] [message: Unable to retrieve local agent IP address] [error: %s]", err)
+				log.Printf("[WARN] [main,podman] [message: Unable to retrieve local agent IP address, using '%s' instead] [error: %s]", options.AgentServerAddr, err)
 				advertiseAddr = options.AgentServerAddr
 			} else {
 				log.Fatalf("[ERROR] [main,docker] [message: Unable to retrieve local agent IP address] [error: %s]", err)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"log"
 	"time"
 
@@ -43,9 +44,9 @@ func main() {
 
 	// !Generic
 
-	// Docker
+	// Docker & Podman
 
-	if containerPlatform == agent.PlatformDocker {
+	if containerPlatform == agent.PlatformDocker || containerPlatform == agent.PlatformPodman {
 		log.Println("[INFO] [main] [message: Agent running on Docker platform]")
 
 		dockerInfoService = docker.NewInfoService()
@@ -71,10 +72,15 @@ func main() {
 
 		advertiseAddr, err = dockerInfoService.GetContainerIpFromDockerEngine(containerName, clusterMode)
 		if err != nil {
-			log.Fatalf("[ERROR] [main,docker] [message: Unable to retrieve local agent IP address] [error: %s]", err)
+			if containerPlatform == agent.PlatformPodman {
+				log.Printf("[WARN] [main,docker] [message: Unable to retrieve local agent IP address] [error: %s]", err)
+				advertiseAddr = options.AgentServerAddr
+			} else {
+				log.Fatalf("[ERROR] [main,docker] [message: Unable to retrieve local agent IP address] [error: %s]", err)
+			}
 		}
 
-		if clusterMode {
+		if containerPlatform == agent.PlatformDocker && clusterMode {
 			clusterService = cluster.NewClusterService(runtimeConfiguration)
 
 			clusterAddr := options.ClusterAddress

--- a/dev-scripts/build.sh
+++ b/dev-scripts/build.sh
@@ -22,6 +22,15 @@ function build() {
     msg "Image $1 is built"
 }
 
+function build_podman() {
+    podman rmi -f "$1" &>/dev/null || true
+
+    msg "Image build..."
+    podman build --no-cache -t "$1" -f build/linux/Dockerfile . &>/dev/null
+
+    msg "Image $1 is built"
+}
+
 function parse_build_params() {
     while :; do
         case "${1-}" in

--- a/dev-scripts/deploy.sh
+++ b/dev-scripts/deploy.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 local=0
+podman=0
 swarm=0
 build=0
 compile=0
@@ -29,7 +30,16 @@ function deploy() {
     fi
 
     if [[ "$build" == "1" ]]; then
-        build "$IMAGE_NAME"
+        if [[ "$podman" == "1" ]]; then
+          build_podman "$IMAGE_NAME"
+        fi
+        if [[ "$local" == "1" ]]; then
+          build "$IMAGE_NAME"
+        fi
+    fi
+
+    if [[ "$podman" == "1" ]]; then
+        deploy_podman
     fi
 
     if [[ "$local" == "1" ]]; then
@@ -64,6 +74,27 @@ function deploy_local() {
         "${IMAGE_NAME}"
 
     docker logs -f portainer-agent-dev
+}
+
+function deploy_podman() {
+    msg "Running local agent $IMAGE_NAME with podman socket"
+
+    #podman rm -f portainer-agent-dev
+
+    # Create local folder for podman volumes
+    mkdir -p /run/user/1000/podman/myvolumes
+
+    podman run -d --name portainer-agent-dev \
+        -e LOG_LEVEL=${LOG_LEVEL} \
+        -e PODMAN_MODE="true" \
+        -v /run/user/1000/podman/podman.sock:/var/run/docker.sock \
+        -v /run/user/1000/podman/myvolumes:/var/lib/docker/volumes \
+        -v /:/host \
+        -p 9001:9001 \
+        -p 8080:80 \
+        "${IMAGE_NAME}"
+
+    podman logs -f portainer-agent-dev
 }
 
 function deploy_swarm() {
@@ -135,6 +166,7 @@ function parse_deploy_params() {
             ;;
         --local) local=1 ;;
         -s | --swarm) swarm=1 ;;
+        -p | --podman) podman=1 ;;
         -c | --compile) compile=1 ;;
         -b | --build) build=1 ;;
         -e | --edge) edge=1 ;;
@@ -177,6 +209,7 @@ Available flags:
 -v, --verbose           Verbose output
 --local                 Deploy to a local docker
 -s, --swarm             Deploy to a swarm cluster
+-p, --podman            Deploy to a local podman
 -c, --compile           Compile the code before deployment (will also build a docker image)
 -b, --build             Build the image before deployment
 -e, --edge              Deploy an edge agent

--- a/dev-scripts/deploy.sh
+++ b/dev-scripts/deploy.sh
@@ -86,7 +86,7 @@ function deploy_podman() {
 
     podman run -d --name portainer-agent-dev \
         -e LOG_LEVEL=${LOG_LEVEL} \
-        -e PODMAN_MODE="true" \
+        -e PODMAN=1 \
         -v /run/user/1000/podman/podman.sock:/var/run/docker.sock \
         -v /run/user/1000/podman/myvolumes:/var/lib/docker/volumes \
         -v /:/host \

--- a/dev.sh
+++ b/dev.sh
@@ -25,6 +25,7 @@ build     Build a docker image
 deploy    Deploy the agent image
 local     Compile, build and deploy a local standalone agent
 swarm     Compile, build and deploy a swarm agent
+podman    Compile, build and deploy to a local podman agent
 
 To get help with a command use: $cmd command -h
 
@@ -52,6 +53,9 @@ local)
     ;;
 swarm)
     deploy_command -s --ip 10.0.7.10 --ip 10.0.7.11 -c "${@:2}"
+    ;;
+podman)
+    deploy_command -p -c "${@:2}"
     ;;
 *)
     usage

--- a/http/handler/handler.go
+++ b/http/handler/handler.go
@@ -95,7 +95,14 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, request *http.Request) {
 	request.URL.Path = dockerAPIVersionRegexp.ReplaceAllString(request.URL.Path, "")
 	rw.Header().Set(agent.HTTPResponseAgentHeaderName, agent.Version)
 	rw.Header().Set(agent.HTTPResponseAgentApiVersion, agent.APIVersion)
-	rw.Header().Set(agent.HTTPResponseAgentPlatform, strconv.Itoa(int(h.containerPlatform)))
+
+	// When the header is not set to PlatformDocker Portainer assumes the platform to be kubernetes.
+	// However, Portainer should handle podman agents the same way as docker agents.
+	agentPlatformIdentifier := h.containerPlatform
+	if h.containerPlatform == agent.PlatformPodman {
+		agentPlatformIdentifier = agent.PlatformDocker
+	}
+	rw.Header().Set(agent.HTTPResponseAgentPlatform, strconv.Itoa(int(agentPlatformIdentifier)))
 
 	switch {
 	case strings.HasPrefix(request.URL.Path, "/v1"):

--- a/internal/edge/poll.go
+++ b/internal/edge/poll.go
@@ -228,9 +228,16 @@ func (service *PollService) poll() error {
 	}
 
 	req.Header.Set(agent.HTTPEdgeIdentifierHeaderName, service.edgeID)
-	req.Header.Set(agent.HTTPResponseAgentPlatform, strconv.Itoa(int(service.containerPlatform)))
 
-	log.Printf("[DEBUG] [internal,edge,poll] [message: sending agent platform header] [header: %s]", strconv.Itoa(int(service.containerPlatform)))
+	// When the header is not set to PlatformDocker Portainer assumes the platform to be kubernetes.
+	// However, Portainer should handle podman agents the same way as docker agents.
+	agentPlatformIdentifier := service.containerPlatform
+	if service.containerPlatform == agent.PlatformPodman {
+		agentPlatformIdentifier = agent.PlatformDocker
+	}
+	req.Header.Set(agent.HTTPResponseAgentPlatform, strconv.Itoa(int(agentPlatformIdentifier)))
+
+	log.Printf("[DEBUG] [internal,edge,poll] [message: sending agent platform header] [header: %s]", strconv.Itoa(int(agentPlatformIdentifier)))
 
 	if service.httpClient == nil {
 		service.createHTTPClient(clientDefaultPollTimeout)

--- a/os/kubernetes.go
+++ b/os/kubernetes.go
@@ -7,17 +7,22 @@ import (
 )
 
 const (
+	PodmanMode            = "PODMAN_MODE"
 	KubernetesServiceHost = "KUBERNETES_SERVICE_HOST"
 	KubernetesPodIP       = "KUBERNETES_POD_IP"
 )
 
-// DetermineContainerPlatform will check for the existence of the
-// KUBERNETES_SERVICE_HOST environment variable to determine if
-// the container is running inside the Kubernetes platform.
+// DetermineContainerPlatform will check for the existence of the PODMAN_MODE
+// or KUBERNETES_SERVICE_HOST environment variable to determine if
+// the container is running on Podman or inside the Kubernetes platform.
 // Defaults to Docker otherwise.
 func DetermineContainerPlatform() agent.ContainerPlatform {
-	serviceHostEnvVar := os.Getenv(KubernetesServiceHost)
-	if serviceHostEnvVar != "" {
+	podmanModeEnvVar := os.Getenv(PodmanMode)
+	if podmanModeEnvVar != "" {
+		return agent.PlatformPodman
+	}
+	serviceHostKubernetesEnvVar := os.Getenv(KubernetesServiceHost)
+	if serviceHostKubernetesEnvVar != "" {
 		return agent.PlatformKubernetes
 	}
 	return agent.PlatformDocker

--- a/os/kubernetes.go
+++ b/os/kubernetes.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	PodmanMode            = "PODMAN_MODE"
+	PodmanMode            = "PODMAN"
 	KubernetesServiceHost = "KUBERNETES_SERVICE_HOST"
 	KubernetesPodIP       = "KUBERNETES_POD_IP"
 )
@@ -18,7 +18,7 @@ const (
 // Defaults to Docker otherwise.
 func DetermineContainerPlatform() agent.ContainerPlatform {
 	podmanModeEnvVar := os.Getenv(PodmanMode)
-	if podmanModeEnvVar != "" {
+	if podmanModeEnvVar == "1" {
 		return agent.PlatformPodman
 	}
 	serviceHostKubernetesEnvVar := os.Getenv(KubernetesServiceHost)


### PR DESCRIPTION
## Description

I would like to use the portainer agent on podman-based systems. However, with the current develop (3879d95e95fea6d210d8c8a1974793a5c5cc481a) it is not possible to start the agent as a rootless podman container. It always fails to read the IP of the agent of the container network configuration and terminates the process. Since we start the containers on Podman without root privileges it is not possible to make a network assignment.

As a solution, we thought of adding a dedicated Podman mode for the agent (similar to Docker/Swarm/Kubernetes/Edge). When running the agent with podman the host address is used as advertising address. With these changes, it is possible to run the agent on Podman as root container as well as rootless container.

## General Setup 

This section describes the general setup to successfully run the portainer agent with podman. 

1) Clone PR
2) Install Podman (version: 3.0.1)
3) Start Podman-API-Socket (`podman system service -t 0`). This command starts the API-Socket with a specific timeout. The parameter `-t 0` sets the timeout to unlimited. The command should be executed in the background or in a terminal. 
4) Start Container `./dev podman`
