### PR TITLE
Clarify used base64 encoding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ to access the Edge UI again.
 
 ### Edge key
 
-The Edge key is used by the agent to connect to a specific Portainer instance. It is encoded using base64 and contains the following information:
+The Edge key is used by the agent to connect to a specific Portainer instance. It is encoded using `base64` format (without the padding characters) and contains the following information:
 
 * Portainer instance API URL
 * Portainer instance tunnel server address
@@ -189,7 +189,7 @@ The following protocol is used between a Portainer instance and an agent:
 
 For each HTTP request made from the Portainer instance to the agent:
 
-1. The Portainer instance generates a signature using its private key. It encodes this signature in base64 and add it to the `X-PortainerAgent-Signature` header of the request
+1. The Portainer instance generates a signature using its private key. It encodes this signature in `base64` format (without the padding characters) and add it to the `X-PortainerAgent-Signature` header of the request
 2. The Portainer instance encodes its public key in hexadecimal and adds it the `X-PortainerAgent-PublicKey` header of the request
 
 


### PR DESCRIPTION
* The agent uses unpadded base64 encoding

The code base uses [`RawStdEncoding`](https://golang.org/pkg/encoding/base64/#pkg-variables) which uses unpadded base64 encoding.

I spent an unhealthy amount of time figuring out why my manually-encoded base64 Edge Key was not being recognised by the Portainer Agent until I realised it needed to be unpadded :)

