### PR TITLE
feat(server): stop if not associated [EE-1610]

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ This mode will allow multiple instances of Portainer to connect to a single agen
 
 Note: Due to the fact that the agent will now decode and parse the public key associated to each request, this mode might be less performant than the default mode.
 
-If `AGENT_SECRET` isn't supplied, the agent will turn off after 3 days if not associated to any Portainer instance. This duration can be changed by supplying `AGENT_SECURITY_SHUTDOWN` environment variable in the format "3d5h2s"
+If `AGENT_SECRET` isn't supplied, the agent will turn off after 3 days if not associated to any Portainer instance. This duration can be changed by supplying `AGENT_SECRET_TIMEOUT` environment variable in the format "20h2s" (https://pkg.go.dev/time#ParseDuration)
 
 ## Deployment options
 
@@ -236,7 +236,7 @@ we can leverage the internal Docker DNS to automatically join existing agents or
 * AGENT_HOST (*optional*): address on which the agent API will be exposed (default to `0.0.0.0`)
 * AGENT_PORT (*optional*): port on which the agent API will be exposed (default to `9001`)
 * AGENT_SECRET (*optional*): shared secret used in the signature verification process
-* AGENT_SECURITY_SHUTDOWN (*optional*): the duration after which the agent will be shutdown if not associated or secured by `AGENT_SECRET`. (defaults to `3d`)
+* AGENT_SECRET_TIMEOUT (*optional*): the duration after which the agent will be shutdown if not associated or secured by `AGENT_SECRET`. (defaults to `72h`)
 * LOG_LEVEL (*optional*): defines the log output verbosity (default to `INFO`)
 * EDGE (*optional*): enable Edge mode. Disabled by default, set to `1` to enable it
 * EDGE_KEY (*optional*): specify an Edge key to use at startup

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ This mode will allow multiple instances of Portainer to connect to a single agen
 
 Note: Due to the fact that the agent will now decode and parse the public key associated to each request, this mode might be less performant than the default mode.
 
+If `AGENT_SECRET` isn't supplied, the agent will turn off after 3 days if not associated to any Portainer instance. This duration can be changed by supplying `AGENT_SECURITY_SHUTDOWN` environment variable in the format "3d5h2s"
+
 ## Deployment options
 
 The behavior of the agent can be tuned via a set of mandatory and optional options available as environment variables:
@@ -234,6 +236,7 @@ we can leverage the internal Docker DNS to automatically join existing agents or
 * AGENT_HOST (*optional*): address on which the agent API will be exposed (default to `0.0.0.0`)
 * AGENT_PORT (*optional*): port on which the agent API will be exposed (default to `9001`)
 * AGENT_SECRET (*optional*): shared secret used in the signature verification process
+* AGENT_SECURITY_SHUTDOWN (*optional*): the duration after which the agent will be shutdown if not associated or secured by `AGENT_SECRET`. (defaults to `3d`)
 * LOG_LEVEL (*optional*): defines the log output verbosity (default to `INFO`)
 * EDGE (*optional*): enable Edge mode. Disabled by default, set to `1` to enable it
 * EDGE_KEY (*optional*): specify an Edge key to use at startup

--- a/agent.go
+++ b/agent.go
@@ -122,6 +122,7 @@ type (
 
 	// DigitalSignatureService is used to validate digital signatures.
 	DigitalSignatureService interface {
+		IsAssociated() bool
 		VerifySignature(signature, key string) (bool, error)
 	}
 
@@ -178,6 +179,8 @@ const (
 	DefaultAgentPort = "9001"
 	// DefaultLogLevel is the default logging level.
 	DefaultLogLevel = "INFO"
+	// DefaultAgentSecurityShutdown is the default time after which the API server will shutdown if not associated with a Portainer instance
+	DefaultAgentSecurityShutdown = "3d"
 	// DefaultEdgeSecurityShutdown is the default time after which the Edge server will shutdown if no key is specified
 	DefaultEdgeSecurityShutdown = 15
 	// DefaultEdgeServerAddr is the default address used by the Edge server.

--- a/agent.go
+++ b/agent.go
@@ -184,7 +184,7 @@ const (
 	// DefaultLogLevel is the default logging level.
 	DefaultLogLevel = "INFO"
 	// DefaultAgentSecurityShutdown is the default time after which the API server will shutdown if not associated with a Portainer instance
-	DefaultAgentSecurityShutdown = "3d"
+	DefaultAgentSecurityShutdown = "72h"
 	// DefaultEdgeSecurityShutdown is the default time after which the Edge server will shutdown if no key is specified
 	DefaultEdgeSecurityShutdown = 15
 	// DefaultEdgeServerAddr is the default address used by the Edge server.

--- a/agent.go
+++ b/agent.go
@@ -1,6 +1,9 @@
 package agent
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 type (
 	// ClusterMember is the representation of an agent inside a cluster.
@@ -55,6 +58,7 @@ type (
 	Options struct {
 		AgentServerAddr       string
 		AgentServerPort       string
+		AgentSecurityShutdown time.Duration
 		ClusterAddress        string
 		HostManagementEnabled bool
 		SharedSecret          string

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	gohttp "net/http"
+	"runtime"
 	"time"
 
 	"github.com/portainer/agent"
@@ -232,9 +235,11 @@ func main() {
 	}
 
 	err = startAPIServer(config)
-	if err != nil {
+	if err != nil && !errors.Is(err, gohttp.ErrServerClosed) {
 		log.Fatalf("[ERROR] [main,http] [message: Unable to start Agent API server] [error: %s]", err)
 	}
+
+	runtime.Goexit()
 
 	// !API
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"log"
 	gohttp "net/http"
-	"runtime"
+	goos "os"
+	"os/signal"
 	"time"
 
 	"github.com/portainer/agent"
@@ -239,7 +240,9 @@ func main() {
 		log.Fatalf("[ERROR] [main,http] [message: Unable to start Agent API server] [error: %s]", err)
 	}
 
-	runtime.Goexit()
+	sigs := make(chan goos.Signal, 1)
+	signal.Notify(sigs)
+	<-sigs
 
 	// !API
 }

--- a/crypto/ecdsa.go
+++ b/crypto/ecdsa.go
@@ -26,6 +26,12 @@ func NewECDSAService(secret string) *ECDSAService {
 	}
 }
 
+// IsAssociated tells if the service is associated with a public key
+// or if it's secured behind  a secret
+func (service *ECDSAService) IsAssociated() bool {
+	return service.publicKey != nil || service.secret != ""
+}
+
 // VerifySignature is used to verify a digital signature using a specified public
 // key. The public key specified as a parameter must be hexadecimal encoded.
 // The public key will be decoded and parsed as DER data. If the service is not

--- a/http/server.go
+++ b/http/server.go
@@ -147,10 +147,6 @@ func (server *APIServer) StartSecured() error {
 				log.Fatalf("[ERROR] [server] [message: failed shutting down server] [error: %s]", err)
 			}
 
-			// Keep alive
-			for {
-				time.Sleep(time.Second)
-			}
 		}
 	}()
 

--- a/http/server.go
+++ b/http/server.go
@@ -136,13 +136,12 @@ func (server *APIServer) StartSecured() error {
 	}
 
 	go func() {
-		agentSecurityShutdown := 10
-
-		timer1 := time.NewTimer(time.Duration(agentSecurityShutdown) * time.Second)
+		securityShutdown := config.AgentOptions.AgentSecurityShutdown
+		timer1 := time.NewTimer(securityShutdown)
 		<-timer1.C
 
 		if !server.signatureService.IsAssociated() {
-			log.Printf("[INFO] [main,http] [message: Shutting down API server as no client was associated after %d minutes , keeping alive to prevent restart by docker/kubernetes]", agentSecurityShutdown)
+			log.Printf("[INFO] [main,http] [message: Shutting down API server as no client was associated after %s, keeping alive to prevent restart by docker/kubernetes]", securityShutdown)
 
 			err := httpServer.Shutdown(context.Background())
 			if err != nil {

--- a/http/server.go
+++ b/http/server.go
@@ -137,8 +137,7 @@ func (server *APIServer) StartSecured() error {
 
 	go func() {
 		securityShutdown := config.AgentOptions.AgentSecurityShutdown
-		timer1 := time.NewTimer(securityShutdown)
-		<-timer1.C
+		time.Sleep(securityShutdown)
 
 		if !server.signatureService.IsAssociated() {
 			log.Printf("[INFO] [main,http] [message: Shutting down API server as no client was associated after %s, keeping alive to prevent restart by docker/kubernetes]", securityShutdown)

--- a/os/options.go
+++ b/os/options.go
@@ -15,6 +15,7 @@ const (
 	EnvKeyAgentPort             = "AGENT_PORT"
 	EnvKeyClusterAddr           = "AGENT_CLUSTER_ADDR"
 	EnvKeyAgentSecret           = "AGENT_SECRET"
+	EnvKeyAgentSecurityShutdown = "AGENT_SECURITY_SHUTDOWN"
 	EnvKeyCapHostManagement     = "CAP_HOST_MANAGEMENT"
 	EnvKeyEdge                  = "EDGE"
 	EnvKeyEdgeKey               = "EDGE_KEY"
@@ -47,6 +48,13 @@ func (parser *EnvOptionParser) Options() (*agent.Options, error) {
 		EdgeInsecurePoll:      false,
 		LogLevel:              agent.DefaultLogLevel,
 	}
+
+	agentSecurityShutdown, err := parseAgentSecurityShutdown()
+	if err != nil {
+		return nil, err
+	}
+
+	options.AgentSecurityShutdown = agentSecurityShutdown
 
 	if os.Getenv(EnvKeyCapHostManagement) != "" {
 		log.Println("[WARN] [os,options] [message: the CAP_HOST_MANAGEMENT environment variable is deprecated and will likely be removed in a future version of Portainer agent]")
@@ -112,4 +120,18 @@ func (parser *EnvOptionParser) Options() (*agent.Options, error) {
 	}
 
 	return options, nil
+}
+
+func parseAgentSecurityShutdown() (time.Duration, error) {
+	agentSecurityShutdownStr := agent.DefaultAgentSecurityShutdown
+	if value := os.Getenv(EnvKeyAgentSecurityShutdown); value != "" {
+		agentSecurityShutdownStr = value
+	}
+
+	duration, err := time.ParseDuration(agentSecurityShutdownStr)
+	if err != nil {
+		return time.Second, errors.New("invalid time duration format in " + EnvKeyAgentSecurityShutdown + " environment variable")
+	}
+
+	return duration, nil
 }

--- a/os/options.go
+++ b/os/options.go
@@ -15,7 +15,7 @@ const (
 	EnvKeyAgentPort             = "AGENT_PORT"
 	EnvKeyClusterAddr           = "AGENT_CLUSTER_ADDR"
 	EnvKeyAgentSecret           = "AGENT_SECRET"
-	EnvKeyAgentSecurityShutdown = "AGENT_SECURITY_SHUTDOWN"
+	EnvKeyAgentSecurityShutdown = "AGENT_SECRET_TIMEOUT"
 	EnvKeyCapHostManagement     = "CAP_HOST_MANAGEMENT"
 	EnvKeyEdge                  = "EDGE"
 	EnvKeyEdgeKey               = "EDGE_KEY"


### PR DESCRIPTION
fixes [EE-1610]

this PR introduces a change to non edge agents, where the agent will close its api if it's not associated to a Portainer instance after 3 days.

[EE-1610]: https://portainer.atlassian.net/browse/EE-1610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ