### PR TITLE
Compile Agent for ARM processors

### DIFF
--- a/dev-scripts/compile.sh
+++ b/dev-scripts/compile.sh
@@ -13,7 +13,7 @@ function compile() {
     mkdir -p $TARGET_DIST
 
     cd cmd/agent || exit 1
-    GOOS="linux" GOARCH="amd64" CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s'
+    GOOS="linux" GOARCH="$(go env GOARCH)" CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags '-s'
     rc=$?
     if [[ $rc != 0 ]]; then exit $rc; fi
     cd ../..


### PR DESCRIPTION
Allows `./dev.sh compile` to compile for ARM processors.