### PR TITLE
feat(edge): introduce support for image sync

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -33,8 +33,9 @@ type (
 
 	// EdgeStackConfig represent an Edge stack config
 	EdgeStackConfig struct {
-		Name        string
-		FileContent string
+		Name         string
+		FileContent  string
+		ImageMapping map[string]string // a map of stackfile image to imageCache url(with sha)
 	}
 
 	// HostInfo is the representation of the collection of host information

--- a/dev-scripts/compile.sh
+++ b/dev-scripts/compile.sh
@@ -13,7 +13,7 @@ function compile() {
     mkdir -p $TARGET_DIST
 
     cd cmd/agent || exit 1
-    GOOS="linux" GOARCH="$(go env GOARCH)" CGO_ENABLED=0 go build --installsuffix cgo --ldflags '-s'
+    GOOS="linux" GOARCH="$(go env GOARCH)" CGO_ENABLED=0 go build --installsuffix cgo --ldflags '-s' -tags "containers_image_openpgp,-containers_image_ostree,btrfs_noversion,libdm_no_deferred_remove"
     rc=$?
     if [[ $rc != 0 ]]; then exit $rc; fi
     cd ../..

--- a/edge/client/portainer_client.go
+++ b/edge/client/portainer_client.go
@@ -47,6 +47,7 @@ func NewPortainerClient(serverAddress, endpointID, edgeID string, insecurePoll b
 type stackConfigResponse struct {
 	Name             string
 	StackFileContent string
+	ImageMapping     map[string]string // a map of stackfile image to imageCache url(with sha)
 }
 
 // GetEdgeStackConfig retrieves the configuration associated to an Edge stack
@@ -77,7 +78,7 @@ func (client *PortainerClient) GetEdgeStackConfig(edgeStackID int) (*agent.EdgeS
 		return nil, err
 	}
 
-	return &agent.EdgeStackConfig{Name: data.Name, FileContent: data.StackFileContent}, nil
+	return &agent.EdgeStackConfig{Name: data.Name, FileContent: data.StackFileContent, ImageMapping: data.ImageMapping}, nil
 }
 
 type setEdgeStackStatusPayload struct {

--- a/edge/stack/images.go
+++ b/edge/stack/images.go
@@ -1,0 +1,62 @@
+package stack
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/transports/alltransports"
+	"github.com/containers/image/v5/types"
+)
+
+// TODO: this code is copied in the portainer/portainer-ee PR too, should consolidate somewhere
+func copyImage(ctx context.Context, cacheImage, stackImage string) error {
+
+	// allow anything...
+	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+	policyContext, _ := signature.NewPolicyContext(policy)
+
+	srcRef, err := alltransports.ParseImageName("docker://" + cacheImage)
+	if err != nil {
+		return fmt.Errorf("Invalid source name %s: %v", cacheImage, err)
+	}
+	destRef, err := alltransports.ParseImageName("docker-daemon:" + stackImage)
+	if err != nil {
+		return fmt.Errorf("Invalid destination name %s: %v", stackImage, err)
+	}
+	sourceCtx := types.SystemContext{
+		DockerInsecureSkipTLSVerify: types.NewOptionalBool(true),
+	}
+	destinationCtx := types.SystemContext{
+		DockerInsecureSkipTLSVerify: types.NewOptionalBool(true),
+	}
+
+	log.Printf(
+		"Copy %v to %v",
+		srcRef,
+		destRef,
+	)
+
+	_, err = copy.Image(ctx, policyContext, destRef, srcRef, &copy.Options{
+		//RemoveSignatures:      opts.removeSignatures,
+		//SignBy:                opts.signByFingerprint,
+		//SignPassphrase:        passphrase,
+		ReportWriter:   os.Stdout,
+		SourceCtx:      &sourceCtx,
+		DestinationCtx: &destinationCtx,
+		//ForceManifestMIMEType: manifestType,
+		ImageListSelection: copy.CopySystemImage,
+		//PreserveDigests:       opts.preserveDigests,
+		// OciDecryptConfig:      decConfig,
+		// OciEncryptLayers:      encLayers,
+		// OciEncryptConfig:      encConfig,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Replaces https://github.com/portainer/agent/pull/231

Rebase the PR above on top of the ce-2.13 branch and contain only changes required for image syncing on the agent side.

Requires https://github.com/portainer/portainer-ee/pull/1185

Reference: https://portainer.atlassian.net/browse/EE-1120
