### PR TITLE
feat(nomad/edge): support https for Nomad [EE-2871]

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -280,6 +280,8 @@ const (
 	// ResponseMetadataKey is the JSON field used to store any Portainer related information in
 	// response objects.
 	ResponseMetadataKey = "Portainer"
+	// TLSCACertPath is the default path to the TLS CA certificate file.
+	TLSCACertPath = "ca.pem"
 	// TLSCertPath is the default path to the TLS certificate file.
 	TLSCertPath = "cert.pem"
 	// TLSKeyPath is the default path to the TLS key file.

--- a/agent.go
+++ b/agent.go
@@ -96,8 +96,12 @@ type (
 	}
 
 	NomadConfig struct {
-		NomadAddr  string
-		NomadToken string
+		NomadAddr       string
+		NomadToken      string
+		NomadTLSEnabled bool
+		NomadCACert     string
+		NomadClientCert string
+		NomadClientKey  string
 	}
 
 	// PciDevice is the representation of a physical pci device on a host
@@ -259,6 +263,12 @@ const (
 	NomadTokenEnvVarName = "NOMAD_TOKEN"
 	// NomadAddrEnvVarName represent the name of environment variable of the Nomad addr
 	NomadAddrEnvVarName = "NOMAD_ADDR"
+	// NomadCACertEnvVarName represent the name of environment variable of the Nomad ca certificate
+	NomadCACertEnvVarName = "NOMAD_CACERT"
+	// NomadClientCertEnvVarName represent the name of environment variable of the Nomad client certificate
+	NomadClientCertEnvVarName = "NOMAD_CLIENT_CERT"
+	// NomadClientKeyEnvVarName represent the name of environment variable of the Nomad client key
+	NomadClientKeyEnvVarName = "NOMAD_CLIENT_KEY"
 	// HTTPResponseAgentApiVersion is the name of the header that will have the
 	// Portainer Agent API Version.
 	HTTPResponseAgentApiVersion = "Portainer-Agent-API-Version"

--- a/agent.go
+++ b/agent.go
@@ -269,6 +269,12 @@ const (
 	NomadClientCertEnvVarName = "NOMAD_CLIENT_CERT"
 	// NomadClientKeyEnvVarName represent the name of environment variable of the Nomad client key
 	NomadClientKeyEnvVarName = "NOMAD_CLIENT_KEY"
+	// NomadCACertContentEnvVarName represent the name of environment variable of the Nomad ca certificate content
+	NomadCACertContentEnvVarName = "NOMAD_CACERT_CONTENT"
+	// NomadClientCertContentEnvVarName represent the name of environment variable of the Nomad client certificate content
+	NomadClientCertContentEnvVarName = "NOMAD_CLIENT_CERT_CONTENT"
+	// NomadClientKeyContentEnvVarName represent the name of environment variable of the Nomad client key content
+	NomadClientKeyContentEnvVarName = "NOMAD_CLIENT_KEY_CONTENT"
 	// HTTPResponseAgentApiVersion is the name of the header that will have the
 	// Portainer Agent API Version.
 	HTTPResponseAgentApiVersion = "Portainer-Agent-API-Version"
@@ -280,8 +286,12 @@ const (
 	// ResponseMetadataKey is the JSON field used to store any Portainer related information in
 	// response objects.
 	ResponseMetadataKey = "Portainer"
-	// TLSCACertPath is the default path to the TLS CA certificate file.
-	TLSCACertPath = "ca.pem"
+	// NomadTLSCACertPath is the default path to the Nomad TLS CA certificate file.
+	NomadTLSCACertPath = "nomad-ca.pem"
+	// NomadTLSCertPath is the default path to the Nomad TLS certificate file.
+	NomadTLSCertPath = "nomad-cert.pem"
+	// NomadTLSKeyPath is the default path to the Nomad TLS key file.
+	NomadTLSKeyPath = "nomad-key.pem"
 	// TLSCertPath is the default path to the TLS certificate file.
 	TLSCertPath = "cert.pem"
 	// TLSKeyPath is the default path to the TLS key file.

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -187,37 +187,37 @@ func main() {
 			nomadConfig.NomadTLSEnabled = true
 
 			// Write the TLS certificate into files and update the paths to nomadConfig for Reversy Tunnel API use
-			nomadCACertContent := goos.Getenv(agent.NomadCACertEnvVarName)
+			nomadCACertContent := goos.Getenv(agent.NomadCACertContentEnvVarName)
 			if len(nomadCACertContent) == 0 {
 				log.Fatalf("[ERROR] [main] [message: Nomad CA Certificate is not exported] [error: %s]", err)
 			} else {
-				err = filesystem.WriteFile(options.DataPath, agent.TLSCACertPath, []byte(nomadCACertContent), 0644)
+				err = filesystem.WriteFile(options.DataPath, agent.NomadTLSCACertPath, []byte(nomadCACertContent), 0600)
 				if err != nil {
 					log.Fatalf("[ERROR] [main] [message: Fail to write the Nomad CA Certificate] [error: %s]", err)
 				}
-				nomadConfig.NomadCACert = path.Join(options.DataPath, agent.TLSCACertPath)
+				nomadConfig.NomadCACert = path.Join(options.DataPath, agent.NomadTLSCACertPath)
 			}
 
-			nomadClientCertContent := goos.Getenv(agent.NomadClientCertEnvVarName)
+			nomadClientCertContent := goos.Getenv(agent.NomadClientCertContentEnvVarName)
 			if len(nomadClientCertContent) == 0 {
 				log.Fatalf("[ERROR] [main] [message: Nomad Client Certificate is not exported] [error: %s]", err)
 			} else {
-				err = filesystem.WriteFile(options.DataPath, agent.TLSCertPath, []byte(nomadClientCertContent), 0644)
+				err = filesystem.WriteFile(options.DataPath, agent.NomadTLSCertPath, []byte(nomadClientCertContent), 0600)
 				if err != nil {
 					log.Fatalf("[ERROR] [main] [message: Fail to write the Nomad Client Certificate] [error: %s]", err)
 				}
-				nomadConfig.NomadClientCert = path.Join(options.DataPath, agent.TLSCertPath)
+				nomadConfig.NomadClientCert = path.Join(options.DataPath, agent.NomadTLSCertPath)
 			}
 
-			nomadClientKeyContent := goos.Getenv(agent.NomadClientKeyEnvVarName)
+			nomadClientKeyContent := goos.Getenv(agent.NomadClientKeyContentEnvVarName)
 			if len(nomadClientKeyContent) == 0 {
 				log.Fatalf("[ERROR] [main] [message: Nomad Client Key is not exported] [error: %s]", err)
 			} else {
-				err = filesystem.WriteFile(options.DataPath, agent.TLSKeyPath, []byte(nomadClientKeyContent), 0644)
+				err = filesystem.WriteFile(options.DataPath, agent.NomadTLSKeyPath, []byte(nomadClientKeyContent), 0600)
 				if err != nil {
 					log.Fatalf("[ERROR] [main] [message: Fail to write the Nomad Client Key] [error: %s]", err)
 				}
-				nomadConfig.NomadClientKey = path.Join(options.DataPath, agent.TLSKeyPath)
+				nomadConfig.NomadClientKey = path.Join(options.DataPath, agent.NomadTLSKeyPath)
 			}
 
 			if _, err := goos.Stat(nomadConfig.NomadCACert); errors.Is(err, goos.ErrNotExist) {

--- a/http/handler/nomadproxy/handler.go
+++ b/http/handler/nomadproxy/handler.go
@@ -1,8 +1,9 @@
 package nomadproxy
 
 import (
-	"github.com/portainer/agent"
 	"net/http"
+
+	"github.com/portainer/agent"
 
 	"github.com/gorilla/mux"
 	"github.com/portainer/agent/http/proxy"
@@ -22,7 +23,7 @@ type Handler struct {
 func NewHandler(notaryService *security.NotaryService, nomadConfig agent.NomadConfig) *Handler {
 	h := &Handler{
 		Router:      mux.NewRouter(),
-		nomadProxy:  proxy.NewNomadProxy(nomadConfig.NomadAddr),
+		nomadProxy:  proxy.NewNomadProxy(nomadConfig),
 		nomadConfig: nomadConfig,
 	}
 

--- a/http/handler/nomadproxy/nomad_operation.go
+++ b/http/handler/nomadproxy/nomad_operation.go
@@ -9,9 +9,7 @@ import (
 )
 
 func (handler *Handler) nomadOperation(rw http.ResponseWriter, request *http.Request) *httperror.HandlerError {
-	if handler.nomadConfig.NomadToken != "" {
-		request.Header.Set(agent.HTTPNomadTokenHeaderName, handler.nomadConfig.NomadToken)
-	}
+	request.Header.Set(agent.HTTPNomadTokenHeaderName, handler.nomadConfig.NomadToken)
 	http.StripPrefix("/nomad", handler.nomadProxy).ServeHTTP(rw, request)
 
 	return nil

--- a/http/handler/nomadproxy/nomad_operation.go
+++ b/http/handler/nomadproxy/nomad_operation.go
@@ -1,14 +1,18 @@
 package nomadproxy
 
 import (
-	"github.com/portainer/agent"
 	"net/http"
+
+	"github.com/portainer/agent"
 
 	httperror "github.com/portainer/libhttp/error"
 )
 
 func (handler *Handler) nomadOperation(rw http.ResponseWriter, request *http.Request) *httperror.HandlerError {
-	request.Header.Set(agent.HTTPNomadTokenHeaderName, handler.nomadConfig.NomadToken)
+	if handler.nomadConfig.NomadToken != "" {
+		request.Header.Set(agent.HTTPNomadTokenHeaderName, handler.nomadConfig.NomadToken)
+	}
 	http.StripPrefix("/nomad", handler.nomadProxy).ServeHTTP(rw, request)
+
 	return nil
 }

--- a/http/proxy/nomad.go
+++ b/http/proxy/nomad.go
@@ -2,19 +2,49 @@ package proxy
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+
+	"github.com/portainer/agent"
 )
 
-func NewNomadProxy(nomadAddr string) http.Handler {
-	remoteURL, _ := url.Parse(nomadAddr)
+func NewNomadProxy(nomadConfig agent.NomadConfig) http.Handler {
+	remoteURL, _ := url.Parse(nomadConfig.NomadAddr)
+
 	proxy := httputil.NewSingleHostReverseProxy(remoteURL)
 
-	proxy.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+	if nomadConfig.NomadClientCert != "" && nomadConfig.NomadClientKey != "" {
+		var caCertPool *x509.CertPool
+		// Create a CA certificate pool and add cert.pem to it
+		if nomadConfig.NomadCACert != "" {
+			caCert, err := ioutil.ReadFile(nomadConfig.NomadCACert)
+			if err != nil {
+				log.Fatalf("[ERROR] [proxy,nomad] [message: failed to read Nomad CA Cert]")
+			}
+			caCertPool = x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM(caCert)
+		}
+
+		// Create an HTTPS client and supply the created CA pool and certificate
+		proxy.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    caCertPool,
+				MinVersion: tls.VersionTLS13,
+				MaxVersion: tls.VersionTLS13,
+				GetClientCertificate: func(chi *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+					cert, err := tls.LoadX509KeyPair(nomadConfig.NomadClientCert, nomadConfig.NomadClientKey)
+					if err != nil {
+						return nil, err
+					}
+
+					return &cert, nil
+				},
+			},
+		}
 	}
 
 	return proxy

--- a/http/proxy/nomad.go
+++ b/http/proxy/nomad.go
@@ -17,32 +17,40 @@ func NewNomadProxy(nomadConfig agent.NomadConfig) http.Handler {
 
 	proxy := httputil.NewSingleHostReverseProxy(remoteURL)
 
-	if nomadConfig.NomadClientCert != "" && nomadConfig.NomadClientKey != "" {
-		var caCertPool *x509.CertPool
-		// Create a CA certificate pool and add cert.pem to it
-		if nomadConfig.NomadCACert != "" {
-			caCert, err := ioutil.ReadFile(nomadConfig.NomadCACert)
-			if err != nil {
-				log.Fatalf("[ERROR] [proxy,nomad] [message: failed to read Nomad CA Cert]")
+	if nomadConfig.NomadTLSEnabled {
+		if nomadConfig.NomadClientCert != "" && nomadConfig.NomadClientKey != "" {
+			var caCertPool *x509.CertPool
+			// Create a CA certificate pool and add cert.pem to it
+			if nomadConfig.NomadCACert != "" {
+				caCert, err := ioutil.ReadFile(nomadConfig.NomadCACert)
+				if err != nil {
+					log.Fatalf("[ERROR] [proxy,nomad] [message: failed to read Nomad CA Cert]")
+				}
+				caCertPool = x509.NewCertPool()
+				caCertPool.AppendCertsFromPEM(caCert)
 			}
-			caCertPool = x509.NewCertPool()
-			caCertPool.AppendCertsFromPEM(caCert)
-		}
 
-		// Create an HTTPS client and supply the created CA pool and certificate
+			// Create an HTTPS client and supply the created CA pool and certificate
+			proxy.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:    caCertPool,
+					MinVersion: tls.VersionTLS13,
+					MaxVersion: tls.VersionTLS13,
+					GetClientCertificate: func(chi *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+						cert, err := tls.LoadX509KeyPair(nomadConfig.NomadClientCert, nomadConfig.NomadClientKey)
+						if err != nil {
+							return nil, err
+						}
+
+						return &cert, nil
+					},
+				},
+			}
+		}
+	} else {
 		proxy.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
-				RootCAs:    caCertPool,
-				MinVersion: tls.VersionTLS13,
-				MaxVersion: tls.VersionTLS13,
-				GetClientCertificate: func(chi *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-					cert, err := tls.LoadX509KeyPair(nomadConfig.NomadClientCert, nomadConfig.NomadClientKey)
-					if err != nil {
-						return nil, err
-					}
-
-					return &cert, nil
-				},
+				InsecureSkipVerify: true,
 			},
 		}
 	}

--- a/http/proxy/nomad.go
+++ b/http/proxy/nomad.go
@@ -18,34 +18,37 @@ func NewNomadProxy(nomadConfig agent.NomadConfig) http.Handler {
 	proxy := httputil.NewSingleHostReverseProxy(remoteURL)
 
 	if nomadConfig.NomadTLSEnabled {
-		if nomadConfig.NomadClientCert != "" && nomadConfig.NomadClientKey != "" {
+		tlsClientConfig := &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			MaxVersion: tls.VersionTLS13,
+		}
+
+		// Create a CA certificate pool and add cert.pem to it
+		if nomadConfig.NomadCACert != "" {
 			var caCertPool *x509.CertPool
-			// Create a CA certificate pool and add cert.pem to it
-			if nomadConfig.NomadCACert != "" {
-				caCert, err := ioutil.ReadFile(nomadConfig.NomadCACert)
+			caCert, err := ioutil.ReadFile(nomadConfig.NomadCACert)
+			if err != nil {
+				log.Fatalf("[ERROR] [proxy,nomad] [message: failed to read Nomad CA Cert]")
+			}
+			caCertPool = x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM(caCert)
+			tlsClientConfig.RootCAs = caCertPool
+		}
+
+		if nomadConfig.NomadClientCert != "" && nomadConfig.NomadClientKey != "" {
+			tlsClientConfig.GetClientCertificate = func(chi *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				cert, err := tls.LoadX509KeyPair(nomadConfig.NomadClientCert, nomadConfig.NomadClientKey)
 				if err != nil {
-					log.Fatalf("[ERROR] [proxy,nomad] [message: failed to read Nomad CA Cert]")
+					return nil, err
 				}
-				caCertPool = x509.NewCertPool()
-				caCertPool.AppendCertsFromPEM(caCert)
-			}
 
-			// Create an HTTPS client and supply the created CA pool and certificate
-			proxy.Transport = &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs:    caCertPool,
-					MinVersion: tls.VersionTLS13,
-					MaxVersion: tls.VersionTLS13,
-					GetClientCertificate: func(chi *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-						cert, err := tls.LoadX509KeyPair(nomadConfig.NomadClientCert, nomadConfig.NomadClientKey)
-						if err != nil {
-							return nil, err
-						}
-
-						return &cert, nil
-					},
-				},
+				return &cert, nil
 			}
+		}
+
+		// Create an HTTPS client and supply the created CA pool and certificate
+		proxy.Transport = &http.Transport{
+			TLSClientConfig: tlsClientConfig,
 		}
 	} else {
 		proxy.Transport = &http.Transport{

--- a/nomad/nomad_deployer.go
+++ b/nomad/nomad_deployer.go
@@ -39,10 +39,13 @@ func (d *Deployer) Deploy(ctx context.Context, name string, filePaths []string, 
 
 	newJobFile, err := filesystem.ReadFromFile(filePaths[0])
 	if err != nil {
-		return errors.Wrap(err, "failed to parse Nomad job file")
+		return errors.Wrap(err, "failed to read Nomad job file")
 	}
 
 	newJob, err := d.client.Jobs().ParseHCL(string(newJobFile), true)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse Nomad job file")
+	}
 
 	// An existing backup file means it is an update action
 	// Need to check if the new coming job file has different region, namespace or id settings


### PR DESCRIPTION
closes [EE-2871]

### Changes:

- allow to deploy Portainer edge agent on Nomad environment with TLS enabled
- able to deploy other Nomad job with Edge stack


[EE-2871]: https://portainer.atlassian.net/browse/EE-2871?