### PR TITLE
feat(edge): allow reverse tunnel creation over https EE-3263

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,5 @@ download-binaries:
 clean:
 	@rm -f dist/*
 
+image:
+	@docker build -f build/linux/alpine.Dockerfile -t portainer-agent .

--- a/agent.go
+++ b/agent.go
@@ -133,11 +133,12 @@ type (
 	// TunnelConfig contains all the required information for the agent to establish
 	// a reverse tunnel to a Portainer instance
 	TunnelConfig struct {
-		ServerAddr        string
-		ServerFingerprint string
-		RemotePort        string
-		LocalAddr         string
-		Credentials       string
+		ServerAddr          string
+		ServerFingerprint   string
+		RemotePort          string
+		LocalAddr           string
+		Credentials         string
+		SkipTLSverification bool
 	}
 
 	// ClusterService is used to manage a cluster of agents.

--- a/agent.go
+++ b/agent.go
@@ -133,12 +133,12 @@ type (
 	// TunnelConfig contains all the required information for the agent to establish
 	// a reverse tunnel to a Portainer instance
 	TunnelConfig struct {
-		ServerAddr          string
-		ServerFingerprint   string
-		RemotePort          string
-		LocalAddr           string
-		Credentials         string
-		SkipTLSverification bool
+		ServerAddr        string
+		ServerFingerprint string
+		RemotePort        string
+		LocalAddr         string
+		Credentials       string
+		AgentOptions      *Options
 	}
 
 	// ClusterService is used to manage a cluster of agents.

--- a/chisel/client.go
+++ b/chisel/client.go
@@ -32,13 +32,16 @@ func NewClient() *Client {
 func (client *Client) CreateTunnel(tunnelConfig agent.TunnelConfig) error {
 	remote := fmt.Sprintf("R:%s:%s", tunnelConfig.RemotePort, tunnelConfig.LocalAddr)
 
-	log.Printf("[DEBUG] [chisel] [remote_port: %s] [local_addr: %s] [server: %s] [server_fingerprint: %s] [message: Creating reverse tunnel client]", tunnelConfig.RemotePort, tunnelConfig.LocalAddr, tunnelConfig.ServerAddr, tunnelConfig.ServerFingerprint)
+	log.Printf("[DEBUG] [chisel] [remote_port: %s] [local_addr: %s] [server: %s] [server_skip_tls_verification: %t] [server_fingerprint: %s] [message: Creating reverse tunnel client]", tunnelConfig.RemotePort, tunnelConfig.LocalAddr, tunnelConfig.ServerAddr, tunnelConfig.SkipTLSverification, tunnelConfig.ServerFingerprint)
 
 	config := &chclient.Config{
 		Server:      tunnelConfig.ServerAddr,
 		Remotes:     []string{remote},
 		Fingerprint: tunnelConfig.ServerFingerprint,
 		Auth:        tunnelConfig.Credentials,
+		TLS: chclient.TLSConfig{
+			SkipVerify: tunnelConfig.SkipTLSverification,
+		},
 	}
 
 	chiselClient, err := chclient.NewClient(config)

--- a/edge/edge.go
+++ b/edge/edge.go
@@ -74,6 +74,7 @@ func (manager *Manager) Start() error {
 		InactivityTimeout:       manager.agentOptions.EdgeInactivityTimeout,
 		TunnelCapability:        manager.agentOptions.EdgeTunnel,
 		PortainerURL:            manager.key.PortainerInstanceURL,
+		InsecurePoll:            manager.agentOptions.EdgeInsecurePoll,
 		TunnelServerAddr:        manager.key.TunnelServerAddr,
 		TunnelServerFingerprint: manager.key.TunnelServerFingerprint,
 		ContainerPlatform:       manager.containerPlatform,

--- a/edge/edge.go
+++ b/edge/edge.go
@@ -74,7 +74,7 @@ func (manager *Manager) Start() error {
 		InactivityTimeout:       manager.agentOptions.EdgeInactivityTimeout,
 		TunnelCapability:        manager.agentOptions.EdgeTunnel,
 		PortainerURL:            manager.key.PortainerInstanceURL,
-		InsecurePoll:            manager.agentOptions.EdgeInsecurePoll,
+		AgentOptions:            manager.agentOptions,
 		TunnelServerAddr:        manager.key.TunnelServerAddr,
 		TunnelServerFingerprint: manager.key.TunnelServerFingerprint,
 		ContainerPlatform:       manager.containerPlatform,

--- a/edge/poll.go
+++ b/edge/poll.go
@@ -37,6 +37,7 @@ type PollService struct {
 	edgeManager              *Manager
 	edgeStackManager         *stack.StackManager
 	portainerURL             string
+	insecurePoll             bool
 	tunnelServerAddr         string
 	tunnelServerFingerprint  string
 
@@ -56,6 +57,7 @@ type pollServiceConfig struct {
 	PollFrequency           string
 	TunnelCapability        bool
 	PortainerURL            string
+	InsecurePoll            bool
 	TunnelServerAddr        string
 	TunnelServerFingerprint string
 	ContainerPlatform       agent.ContainerPlatform
@@ -90,6 +92,7 @@ func newPollService(edgeManager *Manager, edgeStackManager *stack.StackManager, 
 		edgeManager:              edgeManager,
 		edgeStackManager:         edgeStackManager,
 		portainerURL:             config.PortainerURL,
+		insecurePoll:             config.InsecurePoll,
 		tunnelServerAddr:         config.TunnelServerAddr,
 		tunnelServerFingerprint:  config.TunnelServerFingerprint,
 		portainerClient:          portainerClient,
@@ -248,11 +251,12 @@ func (service *PollService) createTunnel(encodedCredentials string, remotePort i
 	}
 
 	tunnelConfig := agent.TunnelConfig{
-		LocalAddr:         service.apiServerAddr,
-		ServerAddr:        service.tunnelServerAddr,
-		ServerFingerprint: service.tunnelServerFingerprint,
-		Credentials:       string(credentials),
-		RemotePort:        strconv.Itoa(remotePort),
+		LocalAddr:           service.apiServerAddr,
+		ServerAddr:          service.tunnelServerAddr,
+		ServerFingerprint:   service.tunnelServerFingerprint,
+		Credentials:         string(credentials),
+		RemotePort:          strconv.Itoa(remotePort),
+		SkipTLSverification: service.insecurePoll,
 	}
 
 	err = service.tunnelClient.CreateTunnel(tunnelConfig)

--- a/edge/poll.go
+++ b/edge/poll.go
@@ -37,9 +37,9 @@ type PollService struct {
 	edgeManager              *Manager
 	edgeStackManager         *stack.StackManager
 	portainerURL             string
-	insecurePoll             bool
 	tunnelServerAddr         string
 	tunnelServerFingerprint  string
+	agentOptions             *agent.Options
 
 	// Async mode only
 	pingInterval     time.Duration
@@ -57,10 +57,10 @@ type pollServiceConfig struct {
 	PollFrequency           string
 	TunnelCapability        bool
 	PortainerURL            string
-	InsecurePoll            bool
 	TunnelServerAddr        string
 	TunnelServerFingerprint string
 	ContainerPlatform       agent.ContainerPlatform
+	AgentOptions            *agent.Options
 }
 
 // newPollService returns a pointer to a new instance of PollService, and will start two loops in go routines.
@@ -92,7 +92,7 @@ func newPollService(edgeManager *Manager, edgeStackManager *stack.StackManager, 
 		edgeManager:              edgeManager,
 		edgeStackManager:         edgeStackManager,
 		portainerURL:             config.PortainerURL,
-		insecurePoll:             config.InsecurePoll,
+		agentOptions:             config.AgentOptions,
 		tunnelServerAddr:         config.TunnelServerAddr,
 		tunnelServerFingerprint:  config.TunnelServerFingerprint,
 		portainerClient:          portainerClient,
@@ -251,12 +251,12 @@ func (service *PollService) createTunnel(encodedCredentials string, remotePort i
 	}
 
 	tunnelConfig := agent.TunnelConfig{
-		LocalAddr:           service.apiServerAddr,
-		ServerAddr:          service.tunnelServerAddr,
-		ServerFingerprint:   service.tunnelServerFingerprint,
-		Credentials:         string(credentials),
-		RemotePort:          strconv.Itoa(remotePort),
-		SkipTLSverification: service.insecurePoll,
+		LocalAddr:         service.apiServerAddr,
+		ServerAddr:        service.tunnelServerAddr,
+		ServerFingerprint: service.tunnelServerFingerprint,
+		Credentials:       string(credentials),
+		RemotePort:        strconv.Itoa(remotePort),
+		AgentOptions:      service.agentOptions,
 	}
 
 	err = service.tunnelClient.CreateTunnel(tunnelConfig)


### PR DESCRIPTION
closes [EE-3263] <!-- Jira link number (remove if unknown). Please also add the same [CE-XXX] at the back of the PR title -->

Allows the Portainer agent to establish a tunnel over HTTPS/WSS.

Sets TLS verification based on the INSECURE_POLL parameter if TLS certificates used for mTLS are not available.

[EE-3263]: https://portainer.atlassian.net/browse/EE-3263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ