### PR TITLE
fix(edge): send endpoint id on async poll [EE-3380]

### DIFF
--- a/edge/client/portainer_edge_async_client.go
+++ b/edge/client/portainer_edge_async_client.go
@@ -56,8 +56,9 @@ func (client *PortainerAsyncClient) SetTimeout(t time.Duration) {
 }
 
 type AsyncRequest struct {
-	CommandTimestamp *time.Time `json:"commandTimestamp,omitempty"`
-	Snapshot         *snapshot  `json:"snapshot,omitempty"`
+	CommandTimestamp *time.Time           `json:"commandTimestamp,omitempty"`
+	Snapshot         *snapshot            `json:"snapshot,omitempty"`
+	EndpointId       portainer.EndpointID `json:"endpointId,omitempty"`
 }
 
 type snapshot struct {
@@ -113,6 +114,7 @@ func (client *PortainerAsyncClient) GetEnvironmentStatus(flags ...string) (*Poll
 	pollURL := fmt.Sprintf("%s/api/endpoints/edge/async", client.serverAddress)
 
 	payload := AsyncRequest{}
+	payload.EndpointId = client.getEndpointIDFn()
 
 	var doSnapshot, doCommand bool
 	for _, f := range flags {


### PR DESCRIPTION
fix [EE-3380]

[EE-3380]: https://portainer.atlassian.net/browse/EE-3380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ