### PR TITLE
 fix(log): log insecure agent warning [EE-3415]

### DIFF
--- a/edge/key.go
+++ b/edge/key.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -27,6 +28,11 @@ func (manager *Manager) SetKey(key string) error {
 	edgeKey, err := parseEdgeKey(key)
 	if err != nil {
 		return err
+	}
+
+	u, _ := url.Parse(edgeKey.PortainerInstanceURL)
+	if u.Scheme != "https" {
+		log.Println("[WARN] [edge] [message: This agent has been configured using an insecure connection, which can limit functionality. We recommend updating the agent to use a secure connection.")
 	}
 
 	manager.mu.Lock()

--- a/http/handler/handler.go
+++ b/http/handler/handler.go
@@ -54,7 +54,7 @@ type Config struct {
 	EdgeManager          *edge.Manager
 	RuntimeConfiguration *agent.RuntimeConfiguration
 	NomadConfig          agent.NomadConfig
-	Secured              bool
+	UseTLS               bool
 	ContainerPlatform    agent.ContainerPlatform
 }
 
@@ -62,14 +62,14 @@ var dockerAPIVersionRegexp = regexp.MustCompile(`(/v[0-9]\.[0-9]*)?`)
 
 // NewHandler returns a pointer to a Handler.
 func NewHandler(config *Config) *Handler {
-	agentProxy := proxy.NewAgentProxy(config.ClusterService, config.RuntimeConfiguration, config.Secured)
+	agentProxy := proxy.NewAgentProxy(config.ClusterService, config.RuntimeConfiguration, config.UseTLS)
 	notaryService := security.NewNotaryService(config.SignatureService, true)
 
 	return &Handler{
 		agentHandler:           httpagenthandler.NewHandler(config.ClusterService, notaryService),
 		browseHandler:          browse.NewHandler(agentProxy, notaryService),
 		browseHandlerV1:        browse.NewHandlerV1(agentProxy, notaryService),
-		dockerProxyHandler:     docker.NewHandler(config.ClusterService, config.RuntimeConfiguration, notaryService, config.Secured),
+		dockerProxyHandler:     docker.NewHandler(config.ClusterService, config.RuntimeConfiguration, notaryService, config.UseTLS),
 		dockerhubHandler:       dockerhub.NewHandler(notaryService),
 		keyHandler:             key.NewHandler(notaryService, config.EdgeManager),
 		kubernetesHandler:      kubernetes.NewHandler(notaryService, config.KubernetesDeployer),

--- a/http/server.go
+++ b/http/server.go
@@ -78,7 +78,7 @@ func (server *APIServer) Start(edgeMode bool) error {
 		EdgeManager:          server.edgeManager,
 		KubeClient:           server.kubeClient,
 		KubernetesDeployer:   server.kubernetesDeployer,
-		Secured:              !edgeMode,
+		UseTLS:               !edgeMode,
 		ContainerPlatform:    server.containerPlatform,
 		NomadConfig:          server.nomadConfig,
 	}
@@ -91,11 +91,10 @@ func (server *APIServer) Start(edgeMode bool) error {
 		WriteTimeout: 30 * time.Minute,
 	}
 
-	log.Printf("[INFO] [http] [server_addr: %s] [server_port: %s] [secured: %t] [api_version: %s] [message: Starting Agent API server]", server.addr, server.port, config.Secured, agent.Version)
+	log.Printf("[INFO] [http] [server_addr: %s] [server_port: %s] [use_tls: %t] [api_version: %s] [message: Starting Agent API server]", server.addr, server.port, config.UseTLS, agent.Version)
 
-	if edgeMode {
+	if !config.UseTLS {
 		httpServer.Handler = server.edgeHandler(httpHandler)
-
 		return httpServer.ListenAndServe()
 	}
 

--- a/http/server.go
+++ b/http/server.go
@@ -93,7 +93,7 @@ func (server *APIServer) Start(edgeMode bool) error {
 
 	log.Printf("[INFO] [http] [server_addr: %s] [server_port: %s] [use_tls: %t] [api_version: %s] [message: Starting Agent API server]", server.addr, server.port, config.UseTLS, agent.Version)
 
-	if !config.UseTLS {
+	if edgeMode {
 		httpServer.Handler = server.edgeHandler(httpHandler)
 		return httpServer.ListenAndServe()
 	}


### PR DESCRIPTION
Log a warning if the edge agent is connecting to Portainer without HTTPS

See:  [EE-3415](https://portainer.atlassian.net/browse/EE-3415)