### PR TITLE
chore(dev): enhance dev script [EE-3023]

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -208,9 +208,13 @@ type (
 	}
 )
 
-const (
+var (
 	// Version represents the version of the agent.
 	Version = "2.17.0"
+)
+
+const (
+
 	// APIVersion represents the version of the agent's API.
 	APIVersion = "2"
 	// DefaultAgentAddr is the default address used by the Agent API server.

--- a/dev-scripts/compile.sh
+++ b/dev-scripts/compile.sh
@@ -3,8 +3,12 @@
 AGENT_VERSION=${AGENT_VERSION:-""}
 
 function compile_command() {
-    parse_compile_params "${@:1}"
+   parse_compile_params "${@:1}"
+   
+   compile
+}
 
+function compile() {
     compile_agent
     compile_credential_helper
 }
@@ -17,7 +21,7 @@ function compile_agent() {
 
     cd cmd/agent || exit 1
 
-    cmd=(go build --installsuffix cgo --gcflags="-trimpath $(pwd)")
+    local cmd=(go build --installsuffix cgo --gcflags="-trimpath $(pwd)")
 
     ldflags="-s"
     if [[ -n "$AGENT_VERSION" ]]; then
@@ -25,6 +29,7 @@ function compile_agent() {
     fi
     
     GOOS="linux" GOARCH="$(go env GOARCH)" CGO_ENABLED=0 "${cmd[@]}" --ldflags "$ldflags"
+
     rc=$?
     if [[ $rc != 0 ]]; then exit $rc; fi
     cd ../..
@@ -64,7 +69,7 @@ function parse_compile_params() {
 }
 
 function usage_compile() {
-    cmd_name="./dev.sh"
+    local cmd_name="./dev.sh"
     cat <<EOF
 Usage: $cmd_name compile [-h] [-v|--verbose]
 

--- a/dev.sh
+++ b/dev.sh
@@ -2,6 +2,13 @@
 
 set -Eeuo pipefail
 
+
+DEBUG=${DEBUG:-""}
+if [[ -n "$DEBUG" ]]; then
+    set -x
+fi
+
+
 trap cleanup SIGINT SIGTERM ERR EXIT
 
 # script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)

--- a/edge/client/error_response.go
+++ b/edge/client/error_response.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+func logError(resp *http.Response) {
+	var errorData struct {
+		Details string
+		Message string
+	}
+
+	err := json.NewDecoder(resp.Body).Decode(&errorData)
+	if err != nil {
+		log.Debug().Err(err).Msg("Failed to decode error response")
+		return
+	}
+	log.Debug().Str("error_response_message", errorData.Details).Str("error_response_details", errorData.Details).Int("status_code", resp.StatusCode).Msg("poll request failure]")
+
+	return
+}

--- a/edge/client/portainer_edge_async_client.go
+++ b/edge/client/portainer_edge_async_client.go
@@ -382,6 +382,8 @@ func (client *PortainerAsyncClient) executeAsyncRequest(payload AsyncRequest, po
 	if resp.StatusCode != http.StatusOK {
 		log.Debug().Int("response_code", resp.StatusCode).Msg("poll request failure")
 
+		logError(resp)
+
 		return nil, errors.New("short poll request failed")
 	}
 

--- a/edge/client/portainer_edge_client.go
+++ b/edge/client/portainer_edge_client.go
@@ -3,12 +3,12 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/portainer/agent"
 	portainer "github.com/portainer/portainer/api"
 
@@ -96,6 +96,8 @@ func (client *PortainerEdgeClient) GetEnvironmentStatus(flags ...string) (*PollS
 
 	if resp.StatusCode != http.StatusOK {
 		log.Debug().Int("response_code", resp.StatusCode).Msg("poll request failure]")
+
+		logError(resp)
 
 		return nil, errors.New("short poll request failed")
 	}


### PR DESCRIPTION
this PR adds a few enhancements (mainly) to the dev script, that makes testing [EE-3023] easier
- change deployed container name
- change agent version
- log poll errors
- expose only the ports needed (based on whether container is an agent, edge agent, non/async agent)

[EE-3023]: https://portainer.atlassian.net/browse/EE-3023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ