### PR TITLE
chore(dev): enhance dev script [EE-3023]

### DIFF
--- a/edge/edge.go
+++ b/edge/edge.go
@@ -29,7 +29,7 @@ type (
 		agentOptions      *agent.Options
 		clusterService    agent.ClusterService
 		dockerInfoService agent.DockerInfoService
-		key               *edgeKey
+		key               *EdgeKey
 		logsManager       *scheduler.LogsManager
 		pollService       *PollService
 		stackManager      *stack.StackManager

--- a/edge/key.go
+++ b/edge/key.go
@@ -16,7 +16,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type edgeKey struct {
+type EdgeKey struct {
 	PortainerInstanceURL    string
 	TunnelServerAddr        string
 	TunnelServerFingerprint string
@@ -106,7 +106,7 @@ func (manager *Manager) PropagateKeyInCluster() error {
 
 // parseEdgeKey decodes a base64 encoded key and extract the decoded information from the following
 // format: <portainer_instance_url>|<tunnel_server_addr>|<tunnel_server_fingerprint>|<endpoint_id>
-func ParseEdgeKey(key string) (*edgeKey, error) {
+func ParseEdgeKey(key string) (*EdgeKey, error) {
 	decodedKey, err := base64.RawStdEncoding.DecodeString(key)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func ParseEdgeKey(key string) (*edgeKey, error) {
 		return nil, errors.New("invalid key format")
 	}
 
-	edgeKey := &edgeKey{
+	edgeKey := &EdgeKey{
 		PortainerInstanceURL:    keyInfo[0],
 		TunnelServerAddr:        keyInfo[1],
 		TunnelServerFingerprint: keyInfo[2],
@@ -133,7 +133,7 @@ func ParseEdgeKey(key string) (*edgeKey, error) {
 	return edgeKey, nil
 }
 
-func encodeKey(edgeKey *edgeKey) string {
+func encodeKey(edgeKey *EdgeKey) string {
 	keyInfo := fmt.Sprintf("%s|%s|%s|%d", edgeKey.PortainerInstanceURL, edgeKey.TunnelServerAddr, edgeKey.TunnelServerFingerprint, edgeKey.EndpointID)
 	encodedKey := base64.RawStdEncoding.EncodeToString([]byte(keyInfo))
 	return encodedKey

--- a/edge/key_test.go
+++ b/edge/key_test.go
@@ -15,7 +15,7 @@ func TestKeyDataRace(t *testing.T) {
 	})
 
 	go func() {
-		mgr.SetKey(encodeKey(&edgeKey{}))
+		mgr.SetKey(encodeKey(&EdgeKey{}))
 	}()
 
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
this PR adds a few enhancements (mainly) to the dev script, that makes testing [EE-3023] easier
- change deployed container name
- change agent version
- log poll errors
- expose only the ports needed (based on whether container is an agent, edge agent, non/async agent)

[EE-3023]: https://portainer.atlassian.net/browse/EE-3023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ