### PR TITLE
Temporary disabled health check

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -7,6 +7,6 @@ COPY dist /app/
 COPY static /app/static
 COPY config $HOME/.docker/
 
-HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=1 CMD [ "/app/agent", "--health-check" ]
+# HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=1 CMD [ "/app/agent", "--health-check" ]
 
 ENTRYPOINT ["./agent"]

--- a/build/linux/alpine.Dockerfile
+++ b/build/linux/alpine.Dockerfile
@@ -7,6 +7,6 @@ COPY dist /app/
 COPY static /app/static
 COPY config /root/.docker/
 
-HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=1 CMD [ "/app/agent", "--health-check" ]
+# HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=1 CMD [ "/app/agent", "--health-check" ]
 
 ENTRYPOINT ["./agent"]

--- a/build/windows/Dockerfile
+++ b/build/windows/Dockerfile
@@ -20,6 +20,6 @@ COPY dist /app/
 COPY static /app/static
 COPY config /Users/ContainerAdministrator/.docker/
 
-HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=1 CMD [ "C:/app/agent", "--health-check" ]
+# HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=1 CMD [ "C:/app/agent", "--health-check" ]
 
 ENTRYPOINT ["C:/app/agent.exe"]


### PR DESCRIPTION
Temporally Disabled health check to fix the fatal error at the startup.

@chiptus need a proper fix for the health check function.