### PR TITLE
chore(version): bump version to 2.16.1 [EE-4550]

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -211,7 +211,7 @@ type (
 
 var (
 	// Version represents the version of the agent.
-	Version = "2.16.0"
+	Version = "2.16.1"
 )
 
 const (


### PR DESCRIPTION
Closes [EE-4550](https://portainer.atlassian.net/browse/EE-4550)