### PR TITLE
fix(makefile): not building credential helper for windows [EE-4895]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ agent: ## Build the agent
 
 credential-helper: ## Build the credential helper (used by edge private registries)
 	@echo "Building Portainer credential-helper..."
-	@cd cmd/$(credential-helper); \
+	@cd cmd/docker-credential-portainer; \
 	CGO_ENABLED=0 GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -trimpath --installsuffix cgo --ldflags "-s" -o ../../dist/$(credential-helper)
 
 download-binaries: ## Download dependant binaries

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ agent: ## Build the agent
 
 credential-helper: ## Build the credential helper (used by edge private registries)
 	@echo "Building Portainer credential-helper..."
-	@cd cmd/docker-credential-portainer; \
+	@cd cmd/docker-credential-portainer && \
 	CGO_ENABLED=0 GOOS=$(PLATFORM) GOARCH=$(ARCH) go build -trimpath --installsuffix cgo --ldflags "-s" -o ../../dist/$(credential-helper)
 
 download-binaries: ## Download dependant binaries


### PR DESCRIPTION
Closes:  [EE-4895](https://portainer.atlassian.net/browse/EE-4895)

[EE-4895]: https://portainer.atlassian.net/browse/EE-4895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ