### PR TITLE
feat(edge): allow to supply initial meta fields [EE-3209]

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -84,6 +84,16 @@ type (
 		} `json:"Agent"`
 	}
 
+	EdgeMetaFields struct {
+		// EdgeGroupsIDs - Used for AEEC, the created environment will be added to these edge groups
+		EdgeGroupsIDs []int
+		// EnvironmentGroupID - Used for AEEC, the created environment will be added to this edge group
+		EnvironmentGroupID int
+		// TagsIDs - Used for AEEC, the created environment will be added to these edge tags
+		TagsIDs  []int
+		UpdateID int
+	}
+
 	// Options are the options used to start an agent.
 	Options struct {
 		AssetsPath            string
@@ -104,13 +114,13 @@ type (
 		EdgeInactivityTimeout string
 		EdgeInsecurePoll      bool
 		EdgeTunnel            bool
+		EdgeMetaFields        EdgeMetaFields
 		LogLevel              string
 		LogMode               string
 		HealthCheck           bool
 		SSLCert               string
 		SSLKey                string
 		SSLCACert             string
-		UpdateID              int
 		CertRetryInterval     time.Duration
 		AWSClientCert         string
 		AWSClientKey          string

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -111,7 +111,7 @@ func main() {
 			advertiseAddr = options.AgentServerAddr
 		}
 
-		if containerPlatform == agent.PlatformDocker && options.UpdateID != 0 {
+		if containerPlatform == agent.PlatformDocker && options.EdgeMetaFields.UpdateID != 0 {
 			ctx := context.Background()
 			go func(ctx context.Context) {
 				// retry three times to make sure that the updater container exits by itself.
@@ -120,7 +120,7 @@ func main() {
 				// the container name conflict for remote update next time.
 				err = docker.Retry(ctx, 3, 30*time.Second, docker.CleanUpGhostUpdaterStack)
 				if err != nil {
-					log.Warn().Int("Update ID", options.UpdateID).Err(err).Msg("unable to clean up ghost updater stack")
+					log.Warn().Int("Update ID", options.EdgeMetaFields.UpdateID).Err(err).Msg("unable to clean up ghost updater stack")
 				}
 			}(ctx)
 		}

--- a/edge/client/interface.go
+++ b/edge/client/interface.go
@@ -49,10 +49,10 @@ type setEndpointIDFn func(portainer.EndpointID)
 type getEndpointIDFn func() portainer.EndpointID
 
 // NewPortainerClient returns a pointer to a new PortainerClient instance
-func NewPortainerClient(serverAddress string, setEIDFn setEndpointIDFn, getEIDFn getEndpointIDFn, edgeID string, edgeAsyncMode bool, agentPlatform agent.ContainerPlatform, updateID int, httpClient *http.Client) PortainerClient {
+func NewPortainerClient(serverAddress string, setEIDFn setEndpointIDFn, getEIDFn getEndpointIDFn, edgeID string, edgeAsyncMode bool, agentPlatform agent.ContainerPlatform, metaFields agent.EdgeMetaFields, httpClient *http.Client) PortainerClient {
 	if edgeAsyncMode {
-		return NewPortainerAsyncClient(serverAddress, setEIDFn, getEIDFn, edgeID, agentPlatform, updateID, httpClient)
+		return NewPortainerAsyncClient(serverAddress, setEIDFn, getEIDFn, edgeID, agentPlatform, metaFields, httpClient)
 	}
 
-	return NewPortainerEdgeClient(serverAddress, setEIDFn, getEIDFn, edgeID, agentPlatform, updateID, httpClient)
+	return NewPortainerEdgeClient(serverAddress, setEIDFn, getEIDFn, edgeID, agentPlatform, metaFields, httpClient)
 }

--- a/edge/client/portainer_edge_client.go
+++ b/edge/client/portainer_edge_client.go
@@ -25,7 +25,7 @@ type PortainerEdgeClient struct {
 	getEndpointIDFn getEndpointIDFn
 	edgeID          string
 	agentPlatform   agent.ContainerPlatform
-	updateID        int
+	metaFields      agent.EdgeMetaFields
 	reqCache        *lru.Cache
 }
 
@@ -34,7 +34,7 @@ type globalKeyResponse struct {
 }
 
 // NewPortainerEdgeClient returns a pointer to a new PortainerEdgeClient instance
-func NewPortainerEdgeClient(serverAddress string, setEIDFn setEndpointIDFn, getEIDFn getEndpointIDFn, edgeID string, agentPlatform agent.ContainerPlatform, updateID int, httpClient *http.Client) *PortainerEdgeClient {
+func NewPortainerEdgeClient(serverAddress string, setEIDFn setEndpointIDFn, getEIDFn getEndpointIDFn, edgeID string, agentPlatform agent.ContainerPlatform, metaFields agent.EdgeMetaFields, httpClient *http.Client) *PortainerEdgeClient {
 	c := &PortainerEdgeClient{
 		serverAddress:   serverAddress,
 		setEndpointIDFn: setEIDFn,
@@ -42,7 +42,7 @@ func NewPortainerEdgeClient(serverAddress string, setEIDFn setEndpointIDFn, getE
 		edgeID:          edgeID,
 		agentPlatform:   agentPlatform,
 		httpClient:      httpClient,
-		updateID:        updateID,
+		metaFields:      metaFields,
 	}
 
 	cache, err := lru.New(8)
@@ -64,8 +64,23 @@ func (client *PortainerEdgeClient) GetEnvironmentID() (portainer.EndpointID, err
 		return 0, errors.New("edge ID not set")
 	}
 
+	var payloadJson []byte
+	if len(client.metaFields.EdgeGroupsIDs) > 0 || len(client.metaFields.TagsIDs) > 0 || client.metaFields.EnvironmentGroupID > 0 {
+		payload := &MetaFields{
+			EdgeGroupsIDs:      client.metaFields.EdgeGroupsIDs,
+			TagsIDs:            client.metaFields.TagsIDs,
+			EnvironmentGroupID: client.metaFields.EnvironmentGroupID,
+		}
+
+		var err error
+		payloadJson, err = json.Marshal(payload)
+		if err != nil {
+			return 0, errors.WithMessage(err, "failed to marshal meta fields")
+		}
+	}
+
 	gkURL := fmt.Sprintf("%s/api/endpoints/global-key", client.serverAddress)
-	req, err := http.NewRequest(http.MethodPost, gkURL, nil)
+	req, err := http.NewRequest(http.MethodPost, gkURL, bytes.NewReader(payloadJson))
 	if err != nil {
 		return 0, err
 	}
@@ -112,7 +127,7 @@ func (client *PortainerEdgeClient) GetEnvironmentStatus(flags ...string) (*PollS
 	req.Header.Set(agent.HTTPResponseAgentPlatform, strconv.Itoa(int(client.agentPlatform)))
 	log.Debug().Int("header", int(client.agentPlatform)).Msg("sending agent platform header")
 
-	req.Header.Set(agent.HTTPResponseUpdateIDHeaderName, strconv.Itoa(client.updateID))
+	req.Header.Set(agent.HTTPResponseUpdateIDHeaderName, strconv.Itoa(client.metaFields.UpdateID))
 
 	resp, err := client.httpClient.Do(req)
 	if err != nil {

--- a/edge/client/portainer_edge_client.go
+++ b/edge/client/portainer_edge_client.go
@@ -64,7 +64,8 @@ func (client *PortainerEdgeClient) GetEnvironmentID() (portainer.EndpointID, err
 		return 0, errors.New("edge ID not set")
 	}
 
-	var payloadJson []byte
+	// set default payload
+	payloadJson := []byte("{}")
 	if len(client.metaFields.EdgeGroupsIDs) > 0 || len(client.metaFields.TagsIDs) > 0 || client.metaFields.EnvironmentGroupID > 0 {
 		payload := &MetaFields{
 			EdgeGroupsIDs:      client.metaFields.EdgeGroupsIDs,

--- a/edge/edge.go
+++ b/edge/edge.go
@@ -98,7 +98,7 @@ func (manager *Manager) Start() error {
 		manager.agentOptions.EdgeID,
 		manager.agentOptions.EdgeAsyncMode,
 		agentPlatform,
-		manager.agentOptions.UpdateID,
+		manager.agentOptions.EdgeMetaFields,
 		client.BuildHTTPClient(10, manager.agentOptions),
 	)
 

--- a/edge/scheduler/logs_test.go
+++ b/edge/scheduler/logs_test.go
@@ -17,7 +17,7 @@ func TestDataRace(t *testing.T) {
 		"edgeID",
 		false,
 		agent.PlatformDocker,
-		0,
+		agent.EdgeMetaFields{},
 		&http.Client{},
 	)
 

--- a/os/options.go
+++ b/os/options.go
@@ -157,13 +157,15 @@ func (parser *EnvOptionParser) Options() (*agent.Options, error) {
 	}, nil
 }
 
+const listSeparator = ":"
+
 func parseListValue(flagValue *string) ([]int, error) {
-	if flagValue == nil {
+	if flagValue == nil || *flagValue == "" {
 		return nil, nil
 	}
 
 	var arr []int
-	for _, strValue := range strings.Split(*flagValue, ":") {
+	for _, strValue := range strings.Split(*flagValue, listSeparator) {
 		intValue, err := strconv.Atoi(strValue)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
fix [EE-3209]

- allows to supply EdgeGroupsIDs, TagsIDs, EnvironmentGroupID to pass to auto created environment
- can pass in env-vars or cli flags:
  - `--edge-groups=1:2:3` (or `EDGE_GROUPS=1:2:3`) - a comma separated values of edge group ids
  - `--environment-group=1` `PORTAINER_GROUP=1` - a group id
  - `--tags=4:7:8` `PORTAINER_TAGS=4:7:8` - a comma separated values of tag ids


[EE-3209]: https://portainer.atlassian.net/browse/EE-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ