### PR TITLE
fix(update/ecr): avoid the nil panic and add informative logs [EE-5285]

### DIFF
--- a/edge/aws/aws.go
+++ b/edge/aws/aws.go
@@ -13,6 +13,10 @@ import (
 
 func DoAWSIAMRolesAnywhereAuthAndGetECRCredentials(serverURL string, awsConfig *agent.AWSConfig) (*agent.RegistryCredentials, error) {
 	if serverURL == "" || awsConfig == nil {
+		log.Info().
+			Str("server_url", serverURL).
+			Str("aws configuration region", awsConfig.Region).
+			Msg("incomplete information when using local AWS config for credential lookup")
 		return nil, nil
 	}
 

--- a/edge/registry/server.go
+++ b/edge/registry/server.go
@@ -57,7 +57,7 @@ func (handler *Handler) LookupHandler(rw http.ResponseWriter, r *http.Request) *
 		log.Info().Msg("using local AWS config for credential lookup")
 
 		c, err := aws.DoAWSIAMRolesAnywhereAuthAndGetECRCredentials(serverUrl, handler.awsConfig)
-		if err != nil {
+		if err != nil && err != aws.ErrNoCredentials {
 			return httperror.InternalServerError("Unable to retrieve credentials", err)
 		}
 

--- a/edge/yaml/docker_compose.go
+++ b/edge/yaml/docker_compose.go
@@ -73,11 +73,18 @@ func (y *DockerComposeYaml) AddCredentialsAsEnvForSpecificService(serviceName st
 			return "", err
 		}
 
-		envs["REGISTRY_USED"] = "1"
-		// hardcode username for aws ecr registry
-		// @https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html#examples
-		envs["REGISTRY_USERNAME"] = "AWS"
-		envs["REGISTRY_PASSWORD"] = c.Secret
+		if c == nil {
+			log.Info().Msg("no credential found while using local AWS config")
+			return "", fmt.Errorf("no credential found from registry url: %s", serverUrl)
+		} else {
+			log.Info().Str("registry server url", serverUrl)
+
+			envs["REGISTRY_USED"] = "1"
+			// hardcode username for aws ecr registry
+			// @https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html#examples
+			envs["REGISTRY_USERNAME"] = "AWS"
+			envs["REGISTRY_PASSWORD"] = c.Secret
+		}
 
 	} else if len(y.RegistryCredentials) > 0 {
 		log.Info().Msg("using private registry credential")

--- a/edge/yaml/docker_compose.go
+++ b/edge/yaml/docker_compose.go
@@ -70,13 +70,11 @@ func (y *DockerComposeYaml) AddCredentialsAsEnvForSpecificService(serviceName st
 		// Exchange ECR credential with ECR certificate
 		c, err := aws.DoAWSIAMRolesAnywhereAuthAndGetECRCredentials(serverUrl, y.awsConfig)
 		if err != nil {
+			// It doesn't need to fallback the registry here, so it is unnecessary to check ErrNoCredential error
 			return "", err
 		}
 
-		if c == nil {
-			log.Info().Msg("no credential found while using local AWS config")
-			return "", fmt.Errorf("no credential found from registry url: %s", serverUrl)
-		} else {
+		if c != nil {
 			log.Info().Str("registry server url", serverUrl)
 
 			envs["REGISTRY_USED"] = "1"


### PR DESCRIPTION
closes [EE-5285]

[EE-5285]: https://portainer.atlassian.net/browse/EE-5285?