### PR TITLE
fix(go): bump go version to 1.21.5 [EE-6457]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ on:
 
 env:
   DOCKER_HUB_REPO: portainerci/agent
-  GO_VERSION: 1.21.3
+  GO_VERSION: 1.21.5
 
 jobs:
   build_images:

--- a/.github/workflows/nightly-security-scan.yml
+++ b/.github/workflows/nightly-security-scan.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.21.3
+  GO_VERSION: 1.21.5
 
 jobs:
   server-dependencies:

--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/pr-security.yml"
 
 env:
-  GO_VERSION: 1.21.3
+  GO_VERSION: 1.21.5
 
 jobs:
   server-dependencies:


### PR DESCRIPTION
[EE-6457]

[EE-6457]: https://portainer.atlassian.net/browse/EE-6457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ