### PR TITLE
fix(logs): add NOCOLOR option for use when exporting to greylog etc [EE-6696]

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -435,6 +435,13 @@ func setLoggingMode(mode string) {
 			Out:           goos.Stderr,
 			TimeFormat:    "2006/01/02 03:04PM",
 			FormatMessage: formatMessage})
+	case "NOCOLOR":
+		log.Logger = log.Output(zerolog.ConsoleWriter{
+			Out:           goos.Stderr,
+			TimeFormat:    "2006/01/02 03:04PM",
+			FormatMessage: formatMessage,
+			NoColor:       true,
+		})
 	case "JSON":
 		log.Logger = log.Output(goos.Stderr)
 	}

--- a/os/options.go
+++ b/os/options.go
@@ -68,7 +68,7 @@ var (
 	fDataPath              = kingpin.Flag("data", EnvKeyDataPath+" path to the data folder").Envar(EnvKeyDataPath).Default(agent.DefaultDataPath).String()
 	fSharedSecret          = kingpin.Flag("secret", EnvKeyAgentSecret+" shared secret used in the signature verification process").Envar(EnvKeyAgentSecret).String()
 	fLogLevel              = kingpin.Flag("log-level", EnvKeyLogLevel+" defines the log output verbosity (default to INFO)").Envar(EnvKeyLogLevel).Default(agent.DefaultLogLevel).Enum("ERROR", "WARN", "INFO", "DEBUG")
-	fLogMode               = kingpin.Flag("log-mode", EnvKeyLogMode+" defines the logging output mode").Envar(EnvKeyLogMode).Default("PRETTY").Enum("PRETTY", "JSON")
+	fLogMode               = kingpin.Flag("log-mode", EnvKeyLogMode+" defines the logging output mode").Envar(EnvKeyLogMode).Default("PRETTY").Enum("NOCOLOR", "PRETTY", "JSON")
 	fHealthCheck           = kingpin.Flag("health-check", "run the agent in healthcheck mode and exit after running preflight checks").Envar(EnvKeyHealthCheck).Default("false").Bool()
 	fUpdateID              = kingpin.Flag("update-id", "the edge update identifier that started this agent").Envar(EnvKeyUpdateID).Int()
 


### PR DESCRIPTION
[EE-6696]

[EE-6696]: https://portainer.atlassian.net/browse/EE-6696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ