### PR TITLE
fix(edge/stack): extract namespace from stackpayload in async mode

### DIFF
--- a/edge/stack/stack.go
+++ b/edge/stack/stack.go
@@ -804,6 +804,7 @@ func (manager *StackManager) buildDeployerParams(stackPayload edge.StackPayload,
 	stack.FileName = stackPayload.EntryFileName
 	stack.FileFolder = getStackFileFolder(stack)
 	stack.EnvVars = stackPayload.EnvVars
+	stack.Namespace = stackPayload.Namespace
 
 	err = filesystem.DecodeDirEntries(stackPayload.DirEntries)
 	if err != nil {


### PR DESCRIPTION
Close [EE-6572]

[EE-6572]: https://portainer.atlassian.net/browse/EE-6572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ