### PR TITLE
fix(edge-stacks): refer to merged ce commit EE-6758

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/pkg/errors v0.9.1
-	github.com/portainer/portainer v0.6.1-0.20240222220731-898793c069fc
+	github.com/portainer/portainer v0.6.1-0.20240229225027-a43454076baf
 	github.com/rs/zerolog v1.29.0
 	github.com/stretchr/testify v1.8.4
 	github.com/wI2L/jsondiff v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/portainer/portainer v0.6.1-0.20240222220731-898793c069fc h1:i7jEYM+8GUuIPDAFlOBmMZraAwnrYxSx/pLLDmnuehg=
 github.com/portainer/portainer v0.6.1-0.20240222220731-898793c069fc/go.mod h1:130gjTm+4I04otMJHKJoK8dmU7ipbHKI1D89x2N7ejI=
+github.com/portainer/portainer v0.6.1-0.20240229225027-a43454076baf h1:YiTZqMgGwgXl75nAjhkn+2BDBYAl8jHX8R7KcZknVZo=
+github.com/portainer/portainer v0.6.1-0.20240229225027-a43454076baf/go.mod h1:1jlOtvJ6hOkuA0Ou59ytCEsp9T4KzVjrxBfjrs+ozxQ=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=


### PR DESCRIPTION
refer to the merged ce 2.20 commit: https://github.com/portainer/portainer/commit/a43454076baf58a2534d95e8c5e5a0eea0afd4ef