### PR TITLE
chore(version): version bump to 2.19.6 [EE-7050]

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -260,7 +260,7 @@ type (
 
 var (
 	// Version represents the version of the agent.
-	Version = "2.19.5"
+	Version = "2.19.6"
 )
 
 const (


### PR DESCRIPTION
Closes [EE-7050]

[EE-7050]: https://portainer.atlassian.net/browse/EE-7050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ