### PR TITLE
chore(go): update to Go v1.22.5 EE-7297

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ on:
 
 env:
   DOCKER_HUB_REPO: portainerci/agent
-  GO_VERSION: 1.21.9
+  GO_VERSION: 1.22.5
 
 jobs:
   build_images:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ on:
       - ready_for_review
 
 env:
-  GO_VERSION: 1.21.9
+  GO_VERSION: 1.22.5
 
 jobs:
   run-linters:

--- a/.github/workflows/nightly-security-scan.yml
+++ b/.github/workflows/nightly-security-scan.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.21.9
+  GO_VERSION: 1.22.5
 
 jobs:
   server-dependencies:

--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -13,7 +13,7 @@ on:
       - ".github/workflows/pr-security.yml"
 
 env:
-  GO_VERSION: 1.21.9
+  GO_VERSION: 1.22.5
 
 jobs:
   server-dependencies:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ name: Test
 on: push
 
 env:
-  GO_VERSION: 1.21.9
+  GO_VERSION: 1.22.5
 
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/portainer/agent
 
-go 1.21
+go 1.22
 
-toolchain go1.21.9
+toolchain go1.22.5
 
 require (
 	github.com/Microsoft/go-winio v0.6.1


### PR DESCRIPTION
[EE-7297]

[EE-7297]: https://portainer.atlassian.net/browse/EE-7297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Ref BE-2296