### PR TITLE
chore(docker): add OCI annotations as labels to the Docker images

### DIFF
--- a/build/linux/Dockerfile
+++ b/build/linux/Dockerfile
@@ -12,6 +12,10 @@ COPY dist/kubectl /app/
 COPY static /app/static
 COPY config $HOME/.docker/
 
-LABEL io.portainer.agent true
+LABEL io.portainer.agent true \
+    org.opencontainers.image.title="Portainer Agent" \
+    org.opencontainers.image.description="The Portainer agent" \
+    org.opencontainers.image.source="https://github.com/portainer/agent" \
+    org.opencontainers.image.vendor="Portainer.io"
 
 ENTRYPOINT ["./agent"]

--- a/build/linux/alpine.Dockerfile
+++ b/build/linux/alpine.Dockerfile
@@ -12,6 +12,10 @@ COPY dist/kubectl /app/
 COPY static /app/static
 COPY config $HOME/.docker/
 
-LABEL io.portainer.agent true
+LABEL io.portainer.agent true \
+    org.opencontainers.image.title="Portainer Agent" \
+    org.opencontainers.image.description="The Portainer agent" \
+    org.opencontainers.image.source="https://github.com/portainer/agent" \
+    org.opencontainers.image.vendor="Portainer.io"
 
 ENTRYPOINT ["./agent"]


### PR DESCRIPTION
closes #717

Changes:

* Add new Docker labels `org.opencontainers.image.source` with this repositories URL as the value to the Docker images. This improves the integration with dependency management tools, as described in the related issue https://github.com/portainer/agent/issues/717
* Also sets some other Open Container Image labels that are already being set in the portainer server image.
